### PR TITLE
DBZ-3060 Add support for cassandra version >=3.11.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>3.11.4</version>
+            <version>3.11.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3060

Test OK for Cassandra 3.11.3, 3.11.4 .... And the latest version 3.11.10
