### PR TITLE
[DBZ-3063]: Modify Cassandra Connector to work with customized CommitLogTransfer smoothly

### DIFF
--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -242,6 +242,13 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
             .withType(Type.INT).withDefault(DEFAULT_SNAPSHOT_POLL_INTERVAL_MS);
 
     /**
+     * The amount of time the CommitLogPostProcessor should wait to re-fetch all commitLog files in relocation dir.
+     */
+    public static final int DEFAULT_COMMIT_LOG_RELOCATION_DIR_POLL_INTERVAL_MS = 10000;
+    public static final Field COMMIT_LOG_RELOCATION_DIR_POLL_INTERVAL_MS = Field.create("commit.log.relocation.dir.poll.interval.ms")
+            .withType(Type.INT).withDefault(DEFAULT_COMMIT_LOG_RELOCATION_DIR_POLL_INTERVAL_MS);
+
+    /**
      * A comma-separated list of fully-qualified names of fields that should be excluded from change event message values.
      * Fully-qualified names for fields are in the form {@code <keyspace_name>.<field_name>.<nested_field_name>}.
      */
@@ -314,7 +321,11 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
         Properties props = new Properties();
         this.getConfig().asMap().entrySet().stream()
                 .filter(entry -> entry.getKey().startsWith(COMMIT_LOG_TRANSFER_CONFIG_PREFIX))
-                .forEach(entry -> props.put(entry.getKey(), entry.getValue()));
+                .forEach(entry -> {
+                    String k = entry.getKey().replace(COMMIT_LOG_TRANSFER_CONFIG_PREFIX, "");
+                    Object v = entry.getValue();
+                    props.put(k, v);
+                });
         return props;
     }
 
@@ -432,6 +443,11 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
 
     public Duration snapshotPollIntervalMs() {
         int ms = this.getConfig().getInteger(SNAPSHOT_POLL_INTERVAL_MS);
+        return Duration.ofMillis(ms);
+    }
+
+    public Duration commitLogRelocationDirPollIntervalMs() {
+        int ms = this.getConfig().getInteger(COMMIT_LOG_RELOCATION_DIR_POLL_INTERVAL_MS);
         return Duration.ofMillis(ms);
     }
 

--- a/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -86,10 +86,12 @@ public class CommitLogProcessor extends AbstractProcessor {
             processLastModifiedCommitLog();
             throw new InterruptedException();
         }
-        if (errorCommitLogReprocessEnabled) {
-            commitLogTransfer.getErrorCommitLogFiles();
-        }
         if (initial) {
+            // If commit.log.error.reprocessing.enabled is set to true, download all error commitLog files upon starting for re-processing.
+            if (errorCommitLogReprocessEnabled) {
+                LOGGER.info("CommitLog Error Processing is enabled. Attempting to get all error commitLog files.");
+                commitLogTransfer.getErrorCommitLogFiles();
+            }
             LOGGER.info("Reading existing commit logs in {}", cdcDir);
             File[] commitLogFiles = CommitLogUtil.getCommitLogs(cdcDir);
             Arrays.sort(commitLogFiles, CommitLogUtil::compareCommitLogs);
@@ -129,7 +131,7 @@ public class CommitLogProcessor extends AbstractProcessor {
                     LOGGER.error("Error occurred while processing commit log " + file.getName(), e);
                     throw e;
                 }
-                LOGGER.warn("Error occurred while processing commit log " + file.getName(), e);
+                LOGGER.error("Error occurred while processing commit log " + file.getName(), e);
             }
         }
         catch (InterruptedException e) {

--- a/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
+++ b/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
@@ -57,10 +57,10 @@ public final class CommitLogUtil {
             }
 
             Files.delete(file.toPath());
-            LOGGER.debug("Deleted commit log {} in cdc directory", file.getName());
+            LOGGER.debug("Deleted CommitLog File {}.", file.getPath());
         }
         catch (Exception e) {
-            LOGGER.error("Failed to delete the file {} from cdc directory: ", file.getName(), e);
+            LOGGER.warn("Failed to delete file {}. Error: ", file.getPath(), e);
         }
     }
 


### PR DESCRIPTION
…ommit log transfer configs.

DBZ-3063 Change sleep time for CommitLogPostProcessor.

DBZ-3063 Only download error commitLog files upon starting.

DBZ-3063 Modify error logs when deleting commitlog files.

https://issues.redhat.com/browse/DBZ-3063