### PR TITLE
[DBZ-3334]: Avoid throwing unnecessary errors and change logging levels

### DIFF
--- a/src/main/java/io/debezium/connector/cassandra/AbstractDirectoryWatcher.java
+++ b/src/main/java/io/debezium/connector/cassandra/AbstractDirectoryWatcher.java
@@ -43,11 +43,11 @@ public abstract class AbstractDirectoryWatcher {
     }
 
     public void poll() throws InterruptedException, IOException {
-        LOGGER.debug("Polling commitLogFiles from cdc_raw directory...");
+        LOGGER.info("Polling commitLog files from {} ...", directory);
         WatchKey key = watchService.poll(pollInterval.toMillis(), TimeUnit.MILLISECONDS);
 
         if (key != null) {
-            LOGGER.debug("Detected new commitLogFiles in cdc_raw directory.");
+            LOGGER.info("Detected new commitLog files in {}.", directory);
             for (WatchEvent<?> event : key.pollEvents()) {
                 Path relativePath = (Path) event.context();
                 Path absolutePath = directory.resolve(relativePath);
@@ -59,7 +59,7 @@ public abstract class AbstractDirectoryWatcher {
             key.reset();
         }
         else {
-            LOGGER.debug("No commitLogFile is detected in cdc_raw directory.");
+            LOGGER.info("No commitLogFile is detected in {}.", directory);
         }
     }
 

--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorContext.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorContext.java
@@ -13,6 +13,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.Schema;
 
 import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.cassandra.exceptions.CassandraConnectorTaskException;
 import io.debezium.connector.common.CdcSourceTaskContext;
 
 /**
@@ -58,9 +59,9 @@ public class CassandraConnectorContext extends CdcSourceTaskContext {
             this.offsetWriter = new FileOffsetWriter(this.config.offsetBackingStoreDir());
         }
         catch (Exception e) {
-            // Clean up CassandraClient and FileOffsetWrite if connector context is failed to be initialized completely.
+            // Clean up CassandraClient and FileOffsetWrite if connector context fails to be completely initialized.
             cleanUp();
-            throw e;
+            throw new CassandraConnectorTaskException("Failed to initialize Cassandra Connector Context.", e);
         }
 
     }

--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
@@ -27,9 +27,9 @@ import com.codahale.metrics.servlets.HealthCheckServlet;
 import com.codahale.metrics.servlets.MetricsServlet;
 import com.codahale.metrics.servlets.PingServlet;
 
-import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.connector.cassandra.exceptions.CassandraConnectorConfigException;
+import io.debezium.connector.cassandra.exceptions.CassandraConnectorTaskException;
 import io.debezium.connector.cassandra.network.BuildInfoServlet;
 
 /**
@@ -111,14 +111,14 @@ public class CassandraConnectorTask {
 
         if (taskContext != null) {
             taskContext.cleanUp();
-            LOGGER.info("Cleaned up Cassandra connector task context.");
+            LOGGER.info("Cleaned up Cassandra connector context.");
         }
         LOGGER.info("Stopped Cassandra Connector Task.");
     }
 
     private void initHttpServer() {
         int httpPort = config.httpPort();
-        LOGGER.info("HTTP port is {}", httpPort);
+        LOGGER.debug("HTTP port is {}", httpPort);
         httpServer = new Server(httpPort);
 
         ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
@@ -143,9 +143,9 @@ public class CassandraConnectorTask {
             }
         }
         catch (Exception e) {
-            throw new DebeziumException("Failed to initiate Processor Group.", e);
+            throw new CassandraConnectorTaskException("Failed to initialize Processor Group.", e);
         }
-        LOGGER.info("Initiated Processor Group.");
+        LOGGER.info("Initialized Processor Group.");
     }
 
     private void initJmxReporter(String domain) {
@@ -226,7 +226,7 @@ public class CassandraConnectorTask {
                 }
             }
             catch (Exception e) {
-                throw new DebeziumException("Failed to terminate processor group.", e);
+                throw new CassandraConnectorTaskException("Failed to terminate processor group.", e);
             }
         }
 

--- a/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -102,7 +102,7 @@ public class CommitLogProcessor extends AbstractProcessor {
             }
             // If commit.log.error.reprocessing.enabled is set to true, download all error commitLog files upon starting for re-processing.
             if (errorCommitLogReprocessEnabled) {
-                LOGGER.info("CommitLog Error Processing is enabled. Attempting to get all error commitLog files.");
+                LOGGER.info("CommitLog Error Processing is enabled. Attempting to get all error commitLog files for re-processing.");
                 commitLogTransfer.getErrorCommitLogFiles();
             }
             initial = false;
@@ -142,8 +142,8 @@ public class CommitLogProcessor extends AbstractProcessor {
             }
         }
         catch (InterruptedException e) {
-            LOGGER.error("Interruption while enqueuing EOF Event for file {}", file.getName());
-            throw new CassandraConnectorTaskException("Enqueuing has been interrupted: ", e);
+            throw new CassandraConnectorTaskException(String.format(
+                    "Enqueuing has been interrupted while enqueuing EOF Event for file %s", file.getName()), e);
         }
     }
 
@@ -165,7 +165,7 @@ public class CommitLogProcessor extends AbstractProcessor {
             processCommitLog(lastModified);
         }
         else {
-            LOGGER.info("No commit logs found in {}", DatabaseDescriptor.getCommitLogLocation());
+            LOGGER.debug("No commit logs found in {}", DatabaseDescriptor.getCommitLogLocation());
         }
     }
 }

--- a/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
+++ b/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
@@ -32,35 +32,40 @@ public final class CommitLogUtil {
     /**
      * Move a commit log to a new directory. If the commit log already exists in the new directory, it woull be replaced.
      */
-    public static void moveCommitLog(File file, Path toDir) {
+    public static boolean moveCommitLog(File file, Path toDir) {
         try {
             Matcher filenameMatcher = FILENAME_REGEX_PATTERN.matcher(file.getName());
             if (!filenameMatcher.matches()) {
-                throw new IllegalArgumentException("Cannot move file because " + file.getName() + " does not appear to be a CommitLog");
+                LOGGER.warn("Cannot move file {} because it does not appear to be a CommitLog.", file.getName());
+                return false;
             }
-
             Files.move(file.toPath(), toDir.resolve(file.getName()), REPLACE_EXISTING);
+            LOGGER.debug("Moved CommitLog file {} from {} to {}.", file.getName(), file.getParent(), toDir);
+            return true;
         }
         catch (Exception e) {
-            LOGGER.error("Failed to move the file {} from {}", file.getName(), toDir.getFileName(), e);
+            LOGGER.warn("Failed to move CommitLog file {} from {} to {}. Error:", file.getName(), file.getParent(), toDir, e);
+            return false;
         }
     }
 
     /**
      * Delete a commit log and logs the error in the case the deletion failed.
      */
-    public static void deleteCommitLog(File file) {
+    public static boolean deleteCommitLog(File file) {
         try {
             Matcher filenameMatcher = FILENAME_REGEX_PATTERN.matcher(file.getName());
             if (!filenameMatcher.matches()) {
-                throw new IllegalArgumentException("Cannot delete file because " + file.getName() + " does not appear to be a CommitLog");
+                LOGGER.warn("Cannot delete file {} because it does not appear to be a CommitLog", file.getName());
+                return false;
             }
-
             Files.delete(file.toPath());
-            LOGGER.debug("Deleted CommitLog File {}.", file.getPath());
+            LOGGER.debug("Deleted CommitLog file {} from {}.", file.getName(), file.getParent());
+            return true;
         }
         catch (Exception e) {
-            LOGGER.warn("Failed to delete file {}. Error: ", file.getPath(), e);
+            LOGGER.warn("Failed to delete CommitLog file {} from {}. Error: ", file.getName(), file.getParent(), e);
+            return false;
         }
     }
 

--- a/src/main/java/io/debezium/connector/cassandra/FileOffsetWriter.java
+++ b/src/main/java/io/debezium/connector/cassandra/FileOffsetWriter.java
@@ -117,7 +117,7 @@ public class FileOffsetWriter implements OffsetWriter {
             }
         }
         catch (IOException e) {
-            LOGGER.error("Ignoring flush failure", e);
+            LOGGER.warn("Ignoring flush failure", e);
         }
     }
 
@@ -126,14 +126,14 @@ public class FileOffsetWriter implements OffsetWriter {
             snapshotOffsetFileLock.release();
         }
         catch (IOException e) {
-            LOGGER.error("Failed to release snapshot offset file lock");
+            LOGGER.warn("Failed to release snapshot offset file lock");
         }
 
         try {
             commitLogOffsetFileLock.release();
         }
         catch (IOException e) {
-            LOGGER.error("Failed to release commit log offset file lock");
+            LOGGER.warn("Failed to release commit log offset file lock");
         }
     }
 
@@ -142,8 +142,7 @@ public class FileOffsetWriter implements OffsetWriter {
             props.store(fos, null);
         }
         catch (IOException e) {
-            LOGGER.error("Failed to save offset for file " + offsetFile.getName(), e);
-            throw e;
+            throw new IOException("Failed to save offset for file " + offsetFile.getName());
         }
     }
 
@@ -152,8 +151,7 @@ public class FileOffsetWriter implements OffsetWriter {
             props.load(fis);
         }
         catch (IOException e) {
-            LOGGER.error("Failed to load offset for file " + offsetFile.getName(), e);
-            throw e;
+            throw new IOException("Failed to load offset for file " + offsetFile.getName());
         }
     }
 

--- a/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
@@ -59,10 +59,10 @@ public class KafkaRecordEmitter implements AutoCloseable {
     public void emit(Record record) {
         try {
             synchronized (lock) {
-                LOGGER.debug("Sending the record '{}'", record.toString());
+                LOGGER.info("Sending the record '{}'", record.toString());
                 ProducerRecord<byte[], byte[]> producerRecord = toProducerRecord(record);
                 Future<RecordMetadata> future = producer.send(producerRecord);
-                LOGGER.debug("The record '{}' has been sent", record.toString());
+                LOGGER.info("The record '{}' has been sent", record.toString());
                 futures.put(record, future);
                 maybeFlushAndMarkOffset();
             }
@@ -102,7 +102,7 @@ public class KafkaRecordEmitter implements AutoCloseable {
         try {
             recordEntry.getValue().get(); // wait
             if (++emitCount % 10_000 == 0) {
-                LOGGER.info("Emitted {} records to Kafka Broker", emitCount);
+                LOGGER.debug("Emitted {} records to Kafka Broker", emitCount);
                 emitCount = 0;
             }
             return true;
@@ -124,7 +124,7 @@ public class KafkaRecordEmitter implements AutoCloseable {
         boolean isSnapshot = source.snapshot;
         offsetWriter.markOffset(sourceTable, sourceOffset, isSnapshot);
         if (isSnapshot) {
-            LOGGER.info("Mark snapshot offset for table '{}'", sourceTable);
+            LOGGER.debug("Mark snapshot offset for table '{}'", sourceTable);
         }
     }
 

--- a/src/main/java/io/debezium/connector/cassandra/RecordMaker.java
+++ b/src/main/java/io/debezium/connector/cassandra/RecordMaker.java
@@ -72,8 +72,8 @@ public class RecordMaker {
             consumer.accept(record);
         }
         catch (InterruptedException e) {
-            LOGGER.error("Interruption while enqueuing Change Event {}", record.toString());
-            throw new CassandraConnectorTaskException("Enqueuing has been interrupted: ", e);
+            throw new CassandraConnectorTaskException(String.format(
+                    "Enqueuing has been interrupted while enqueuing Change Event %s", record.toString()), e);
         }
 
         if (operation == Record.Operation.DELETE && emitTombstoneOnDelete) {
@@ -82,9 +82,9 @@ public class RecordMaker {
             try {
                 consumer.accept(tombstoneRecord);
             }
-            catch (Exception e) {
-                LOGGER.error("Interruption while enqueuing Tombstone Event {}", record.toString());
-                throw new CassandraConnectorTaskException("Enqueuing has been interrupted: ", e);
+            catch (InterruptedException e) {
+                throw new CassandraConnectorTaskException(String.format(
+                        "Enqueuing has been interrupted while enqueuing Tombstone Event %s", record.toString()), e);
             }
         }
     }

--- a/src/main/java/io/debezium/connector/cassandra/network/SslContextFactory.java
+++ b/src/main/java/io/debezium/connector/cassandra/network/SslContextFactory.java
@@ -63,8 +63,7 @@ public class SslContextFactory {
                     keyStore.load(is, config.keyStorePassword().toCharArray());
                 }
                 catch (IOException ex) {
-                    LOGGER.error("failed to load the key store: location=" + config.keyStoreLocation() + " type=" + config.keyStoreType());
-                    throw ex;
+                    throw new IOException("Failed to load the key store: location=" + config.keyStoreLocation() + " type=" + config.keyStoreType());
                 }
                 KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(config.getKeyManagerAlgorithm());
                 keyManagerFactory.init(keyStore, config.keyStorePassword().toCharArray());
@@ -74,7 +73,7 @@ public class SslContextFactory {
 
             }
             else {
-                LOGGER.error("KeyStoreLocation was not specified. Building SslContext without certificate. This is not suitable for PRODUCTION");
+                LOGGER.warn("KeyStoreLocation was not specified. Building SslContext without certificate. This is not suitable for PRODUCTION");
                 final SelfSignedCertificate ssc = new SelfSignedCertificate();
 
                 builder = builder.keyManager(ssc.certificate(), ssc.privateKey());
@@ -86,8 +85,7 @@ public class SslContextFactory {
                     trustStore.load(is, config.trustStorePassword().toCharArray());
                 }
                 catch (IOException ex) {
-                    LOGGER.error("failed to load the trust store: location=" + config.trustStoreLocation() + " type=" + config.trustStoreType());
-                    throw ex;
+                    throw new IOException("Failed to load the trust store: location=" + config.trustStoreLocation() + " type=" + config.trustStoreType());
                 }
                 TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(config.trustManagerAlgorithm());
                 trustManagerFactory.init(trustStore);
@@ -96,7 +94,7 @@ public class SslContextFactory {
 
             }
             else {
-                LOGGER.error("TrustStoreLocation was not specified. Building SslContext using InsecureTrustManagerFactory. This is not suitable for PRODUCTION");
+                LOGGER.warn("TrustStoreLocation was not specified. Building SslContext using InsecureTrustManagerFactory. This is not suitable for PRODUCTION");
                 builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
             }
 


### PR DESCRIPTION
- Do not throw unnecessary exceptions.
- Modify logging levels.
- Fix a bug in SchemaHolder which causes redundant schema updates in Cassandra Connector on tables without any schema changes in Cassandra DB.