### PR TITLE
[DBZ-3378]: Add the number of change event queues and queue processors.

### DIFF
--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -240,6 +240,13 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
             .withDescription(
                     "The amount of time the CommitLogPostProcessor should wait to re-fetch all commitLog files in relocation dir, given in milliseconds. Defaults to 10 seconds (10,000 ms).");
 
+    public static final int DEFAULT_NUM_OF_CHANGE_EVENT_QUEUES = 1;
+    public static final Field NUM_OF_CHANGE_EVENT_QUEUES = Field.create("num.of.change.event.queues")
+            .withType(Type.INT)
+            .withDefault(DEFAULT_NUM_OF_CHANGE_EVENT_QUEUES)
+            .withDescription(
+                    "The number of change event queues and queue processors.");
+
     /**
      * A comma-separated list of fully-qualified names of fields that should be excluded from change event message values.
      * Fully-qualified names for fields are in the form {@code <keyspace_name>.<field_name>.<nested_field_name>}.
@@ -443,6 +450,10 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
     public Duration commitLogRelocationDirPollInterval() {
         int ms = this.getConfig().getInteger(COMMIT_LOG_RELOCATION_DIR_POLL_INTERVAL_MS);
         return Duration.ofMillis(ms);
+    }
+
+    public int numOfChangeEventQueues() {
+        return this.getConfig().getInteger(NUM_OF_CHANGE_EVENT_QUEUES);
     }
 
     public List<String> fieldExcludeList() {

--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
@@ -8,6 +8,7 @@ package io.debezium.connector.cassandra;
 import java.io.FileInputStream;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -28,6 +29,7 @@ import com.codahale.metrics.servlets.MetricsServlet;
 import com.codahale.metrics.servlets.PingServlet;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.cassandra.exceptions.CassandraConnectorConfigException;
 import io.debezium.connector.cassandra.exceptions.CassandraConnectorTaskException;
 import io.debezium.connector.cassandra.network.BuildInfoServlet;
@@ -137,7 +139,10 @@ public class CassandraConnectorTask {
             processorGroup.addProcessor(new SchemaProcessor(taskContext));
             processorGroup.addProcessor(new CommitLogProcessor(taskContext));
             processorGroup.addProcessor(new SnapshotProcessor(taskContext));
-            processorGroup.addProcessor(new QueueProcessor(taskContext));
+            List<ChangeEventQueue<Event>> queues = taskContext.getQueues();
+            for (int i = 0; i < queues.size(); i++) {
+                processorGroup.addProcessor(new QueueProcessor(taskContext, i));
+            }
             if (taskContext.getCassandraConnectorConfig().postProcessEnabled()) {
                 processorGroup.addProcessor(new CommitLogPostProcessor(taskContext));
             }

--- a/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
@@ -8,7 +8,6 @@ package io.debezium.connector.cassandra;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -42,11 +41,11 @@ public class KafkaRecordEmitter implements AutoCloseable {
     private Converter keyConverter;
     private Converter valueConverter;
 
-    public KafkaRecordEmitter(String kafkaTopicPrefix, String heartbeatPrefix, Properties kafkaProperties,
+    public KafkaRecordEmitter(String kafkaTopicPrefix, String heartbeatPrefix, KafkaProducer kafkaProducer,
                               OffsetWriter offsetWriter, Duration offsetFlushIntervalMs, long maxOffsetFlushSize,
                               Converter keyConverter, Converter valueConverter, Set<String> erroneousCommitLogs,
                               CommitLogTransfer commitLogTransfer) {
-        this.producer = new KafkaProducer<>(kafkaProperties);
+        this.producer = kafkaProducer;
         this.topicSelector = CassandraTopicSelector.defaultSelector(kafkaTopicPrefix, heartbeatPrefix);
         this.offsetWriter = offsetWriter;
         this.offsetFlushPolicy = offsetFlushIntervalMs.isZero() ? OffsetFlushPolicy.always() : OffsetFlushPolicy.periodic(offsetFlushIntervalMs, maxOffsetFlushSize);

--- a/src/main/java/io/debezium/connector/cassandra/QueueProcessor.java
+++ b/src/main/java/io/debezium/connector/cassandra/QueueProcessor.java
@@ -27,20 +27,20 @@ public class QueueProcessor extends AbstractProcessor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(QueueProcessor.class);
 
-    private static final String NAME = "Change Event Queue Processor";
     private final ChangeEventQueue<Event> queue;
     private final KafkaRecordEmitter kafkaRecordEmitter;
     private final String commitLogRelocationDir;
     private final Set<String> erroneousCommitLogs;
 
+    private static final String NAME_PREFIX = "Queue Processor ";
     public static final String ARCHIVE_FOLDER = "archive";
     public static final String ERROR_FOLDER = "error";
 
-    public QueueProcessor(CassandraConnectorContext context) {
-        this(context, new KafkaRecordEmitter(
+    public QueueProcessor(CassandraConnectorContext context, int index) {
+        this(context, index, new KafkaRecordEmitter(
                 context.getCassandraConnectorConfig().kafkaTopicPrefix(),
                 context.getCassandraConnectorConfig().getHeartbeatTopicsPrefix(),
-                context.getCassandraConnectorConfig().getKafkaConfigs(),
+                context.getKafkaProducer(),
                 context.getOffsetWriter(),
                 context.getCassandraConnectorConfig().offsetFlushIntervalMs(),
                 context.getCassandraConnectorConfig().maxOffsetFlushSize(),
@@ -51,9 +51,9 @@ public class QueueProcessor extends AbstractProcessor {
     }
 
     @VisibleForTesting
-    QueueProcessor(CassandraConnectorContext context, KafkaRecordEmitter emitter) {
-        super(NAME, Duration.ZERO);
-        this.queue = context.getQueue();
+    QueueProcessor(CassandraConnectorContext context, int index, KafkaRecordEmitter emitter) {
+        super(NAME_PREFIX + "[" + index + "]", Duration.ZERO);
+        this.queue = context.getQueues().get(index);
         this.kafkaRecordEmitter = emitter;
         this.erroneousCommitLogs = context.getErroneousCommitLogs();
         this.commitLogRelocationDir = context.getCassandraConnectorConfig().commitLogRelocationDir();

--- a/src/test/java/io/debezium/connector/cassandra/CommitLogProcessorTest.java
+++ b/src/test/java/io/debezium/connector/cassandra/CommitLogProcessorTest.java
@@ -63,7 +63,7 @@ public class CommitLogProcessorTest extends EmbeddedCassandraConnectorTestBase {
         CommitLog.instance.sync(true);
 
         // check to make sure there are no records in the queue to begin with
-        ChangeEventQueue<Event> queue = context.getQueue();
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
         assertEquals(queue.totalCapacity(), queue.remainingCapacity());
 
         // process the logs in commit log directory

--- a/src/test/java/io/debezium/connector/cassandra/QueueProcessorTest.java
+++ b/src/test/java/io/debezium/connector/cassandra/QueueProcessorTest.java
@@ -34,7 +34,7 @@ public class QueueProcessorTest extends EmbeddedCassandraConnectorTestBase {
     public void setUp() throws Exception {
         context = generateTaskContext();
         emitter = mock(KafkaRecordEmitter.class);
-        queueProcessor = new QueueProcessor(context, emitter);
+        queueProcessor = new QueueProcessor(context, 0, emitter);
     }
 
     @After
@@ -47,7 +47,7 @@ public class QueueProcessorTest extends EmbeddedCassandraConnectorTestBase {
         doNothing().when(emitter).emit(any());
 
         int recordSize = 5;
-        ChangeEventQueue<Event> queue = context.getQueue();
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
         for (int i = 0; i < recordSize; i++) {
             CassandraConnectorConfig config = new CassandraConnectorConfig(Configuration.from(new Properties()));
             SourceInfo sourceInfo = new SourceInfo(config, DatabaseDescriptor.getClusterName(),
@@ -69,7 +69,7 @@ public class QueueProcessorTest extends EmbeddedCassandraConnectorTestBase {
         doNothing().when(emitter).emit(any());
 
         int recordSize = 5;
-        ChangeEventQueue<Event> queue = context.getQueue();
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
         for (int i = 0; i < recordSize; i++) {
             CassandraConnectorConfig config = new CassandraConnectorConfig(Configuration.from(new Properties()));
             SourceInfo sourceInfo = new SourceInfo(config, DatabaseDescriptor.getClusterName(),
@@ -90,7 +90,7 @@ public class QueueProcessorTest extends EmbeddedCassandraConnectorTestBase {
     public void testProcessEofEvent() throws Exception {
         doNothing().when(emitter).emit(any());
 
-        ChangeEventQueue<Event> queue = context.getQueue();
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
         File commitLogFile = generateCommitLogFile();
         queue.enqueue(new EOFEvent(commitLogFile));
 

--- a/src/test/java/io/debezium/connector/cassandra/SnapshotProcessorTest.java
+++ b/src/test/java/io/debezium/connector/cassandra/SnapshotProcessorTest.java
@@ -43,7 +43,7 @@ public class SnapshotProcessorTest extends EmbeddedCassandraConnectorTestBase {
             context.getCassandraClient().execute("INSERT INTO " + keyspaceTable("cdc_table2") + "(a, b) VALUES (?, ?)", i + 10, String.valueOf(i + 10));
         }
 
-        ChangeEventQueue<Event> queue = context.getQueue();
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
         assertEquals(queue.totalCapacity(), queue.remainingCapacity());
         snapshotProcessor.process();
         assertEquals(2 * tableSize, queue.totalCapacity() - queue.remainingCapacity());
@@ -84,7 +84,7 @@ public class SnapshotProcessorTest extends EmbeddedCassandraConnectorTestBase {
             context.getCassandraClient().execute("INSERT INTO " + keyspaceTable("non_cdc_table") + "(a, b) VALUES (?, ?)", i, String.valueOf(i));
         }
 
-        ChangeEventQueue<Event> queue = context.getQueue();
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
         assertEquals(queue.totalCapacity(), queue.remainingCapacity());
         snapshotProcessor.process();
         assertEquals(queue.totalCapacity(), queue.remainingCapacity());
@@ -104,7 +104,7 @@ public class SnapshotProcessorTest extends EmbeddedCassandraConnectorTestBase {
         context.getCassandraClient().execute("CREATE TABLE IF NOT EXISTS " + keyspaceTable("cdc_table") + " (a int, b text, PRIMARY KEY(a)) WITH cdc = true;");
         context.getSchemaHolder().refreshSchemas();
 
-        ChangeEventQueue<Event> queue = context.getQueue();
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
         assertEquals(queue.totalCapacity(), queue.remainingCapacity());
         snapshotProcessor.process(); // records empty table to snapshot.offset, so it won't be snapshotted again
         assertEquals(queue.totalCapacity(), queue.remainingCapacity());


### PR DESCRIPTION
Enable Cassandra Connector to have multiple change event queues and queue processors for parallel processing.