### PR TITLE
[DBZ-3417] fix on-the-fly schema changes

### DIFF
--- a/src/main/java/io/debezium/connector/cassandra/CassandraClient.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraClient.java
@@ -95,6 +95,10 @@ public class CassandraClient implements AutoCloseable {
         return cluster.getMetadata().getClusterName();
     }
 
+    public Cluster getCluster() {
+        return cluster;
+    }
+
     public boolean isQueryable() {
         return !cluster.isClosed() && !session.isClosed();
     }

--- a/src/main/java/io/debezium/connector/cassandra/NoOpSchemaChangeListener.java
+++ b/src/main/java/io/debezium/connector/cassandra/NoOpSchemaChangeListener.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra;
+
+import com.datastax.driver.core.AggregateMetadata;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.FunctionMetadata;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.MaterializedViewMetadata;
+import com.datastax.driver.core.SchemaChangeListener;
+import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.UserType;
+
+public class NoOpSchemaChangeListener implements SchemaChangeListener {
+    @Override
+    public void onKeyspaceAdded(final KeyspaceMetadata keyspace) {
+
+    }
+
+    @Override
+    public void onKeyspaceRemoved(final KeyspaceMetadata keyspace) {
+
+    }
+
+    @Override
+    public void onKeyspaceChanged(final KeyspaceMetadata current, final KeyspaceMetadata previous) {
+
+    }
+
+    @Override
+    public void onTableAdded(final TableMetadata table) {
+
+    }
+
+    @Override
+    public void onTableRemoved(final TableMetadata table) {
+
+    }
+
+    @Override
+    public void onTableChanged(final TableMetadata current, final TableMetadata previous) {
+
+    }
+
+    @Override
+    public void onUserTypeAdded(final UserType type) {
+
+    }
+
+    @Override
+    public void onUserTypeRemoved(final UserType type) {
+
+    }
+
+    @Override
+    public void onUserTypeChanged(final UserType current, final UserType previous) {
+
+    }
+
+    @Override
+    public void onFunctionAdded(final FunctionMetadata function) {
+
+    }
+
+    @Override
+    public void onFunctionRemoved(final FunctionMetadata function) {
+
+    }
+
+    @Override
+    public void onFunctionChanged(final FunctionMetadata current, final FunctionMetadata previous) {
+
+    }
+
+    @Override
+    public void onAggregateAdded(final AggregateMetadata aggregate) {
+
+    }
+
+    @Override
+    public void onAggregateRemoved(final AggregateMetadata aggregate) {
+
+    }
+
+    @Override
+    public void onAggregateChanged(final AggregateMetadata current, final AggregateMetadata previous) {
+
+    }
+
+    @Override
+    public void onMaterializedViewAdded(final MaterializedViewMetadata view) {
+
+    }
+
+    @Override
+    public void onMaterializedViewRemoved(final MaterializedViewMetadata view) {
+
+    }
+
+    @Override
+    public void onMaterializedViewChanged(final MaterializedViewMetadata current, final MaterializedViewMetadata previous) {
+
+    }
+
+    @Override
+    public void onRegister(final Cluster cluster) {
+
+    }
+
+    @Override
+    public void onUnregister(final Cluster cluster) {
+
+    }
+}

--- a/src/main/java/io/debezium/connector/cassandra/SchemaProcessor.java
+++ b/src/main/java/io/debezium/connector/cassandra/SchemaProcessor.java
@@ -5,24 +5,243 @@
  */
 package io.debezium.connector.cassandra;
 
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Map;
+
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.Schema;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.SchemaChangeListener;
+import com.datastax.driver.core.TableMetadata;
+
+import io.debezium.connector.SourceInfoStructMaker;
+
 /**
- * The schema processor is responsible for periodically
- * refreshing the table schemas in Cassandra. Cassandra
- * CommitLog does not provide schema change as events,
- * so we pull the schema regularly for updates.
+ * The schema processor is reponsible for handling changes occuring in
+ * Cassandra via registered schema change listener into driver.
  */
 public class SchemaProcessor extends AbstractProcessor {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchemaProcessor.class);
+
     private static final String NAME = "Schema Processor";
     private final SchemaHolder schemaHolder;
+    private final CassandraClient cassandraClient;
+    private final String kafkaTopicPrefix;
+    private final SourceInfoStructMaker sourceInfoStructMaker;
+    private final SchemaChangeListener schemaChangeListener;
 
     public SchemaProcessor(CassandraConnectorContext context) {
         super(NAME, context.getCassandraConnectorConfig().schemaPollInterval());
         schemaHolder = context.getSchemaHolder();
+        this.cassandraClient = context.getCassandraClient();
+        this.kafkaTopicPrefix = schemaHolder.kafkaTopicPrefix;
+        this.sourceInfoStructMaker = schemaHolder.sourceInfoStructMaker;
+
+        schemaChangeListener = new NoOpSchemaChangeListener() {
+            @Override
+            public void onKeyspaceAdded(final KeyspaceMetadata keyspace) {
+                try {
+                    Schema.instance.setKeyspaceMetadata(org.apache.cassandra.schema.KeyspaceMetadata.create(
+                            keyspace.getName(),
+                            KeyspaceParams.create(keyspace.isDurableWrites(),
+                                    keyspace.getReplication())));
+                    Keyspace.openWithoutSSTables(keyspace.getName());
+                    LOGGER.info("Added keyspace {}", keyspace.asCQLQuery());
+                }
+                catch (Throwable t) {
+                    LOGGER.error("Error happened while adding the keyspace {}", keyspace.getName(), t);
+                }
+            }
+
+            @Override
+            public void onKeyspaceChanged(final KeyspaceMetadata current, final KeyspaceMetadata previous) {
+                try {
+                    Schema.instance.updateKeyspace(current.getName(), KeyspaceParams.create(current.isDurableWrites(), current.getReplication()));
+                    LOGGER.info("Updated keyspace {}", current.asCQLQuery());
+                }
+                catch (Throwable t) {
+                    LOGGER.error("Error happened while updating the keyspace {}", current.getName(), t);
+                }
+            }
+
+            @Override
+            public void onKeyspaceRemoved(final KeyspaceMetadata keyspace) {
+                try {
+                    schemaHolder.removeSchemasOfAllTablesInKeyspace(keyspace.getName());
+                    Schema.instance.clearKeyspaceMetadata(org.apache.cassandra.schema.KeyspaceMetadata.create(
+                            keyspace.getName(),
+                            KeyspaceParams.create(keyspace.isDurableWrites(),
+                                    keyspace.getReplication())));
+                    LOGGER.info("Removed keyspace {}", keyspace.asCQLQuery());
+                }
+                catch (Throwable t) {
+                    LOGGER.error("Error happened while removing the keyspace {}", keyspace.getName(), t);
+                }
+            }
+
+            @Override
+            public void onTableAdded(final TableMetadata tableMetadata) {
+                try {
+                    LOGGER.debug("Table {}.{} detected to be added!", tableMetadata.getKeyspace().getName(), tableMetadata.getName());
+                    if (tableMetadata.getOptions().isCDC()) {
+                        schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(tableMetadata),
+                                new SchemaHolder.KeyValueSchema(kafkaTopicPrefix, tableMetadata, sourceInfoStructMaker));
+                    }
+
+                    final CFMetaData rawCFMetaData = CFMetaData.compile(tableMetadata.asCQLQuery(), tableMetadata.getKeyspace().getName());
+                    // we need to copy because CFMetaData.compile will generate new cfId which would not match id of old metadata
+                    final CFMetaData newCFMetaData = rawCFMetaData.copy(tableMetadata.getId());
+
+                    Keyspace.open(newCFMetaData.ksName).initCf(newCFMetaData, false);
+
+                    final org.apache.cassandra.schema.KeyspaceMetadata current = Schema.instance.getKSMetaData(newCFMetaData.ksName);
+                    if (current == null) {
+                        LOGGER.warn("Keyspace {} doesn't exist", newCFMetaData.ksName);
+                        return;
+                    }
+
+                    if (current.tables.get(tableMetadata.getName()).isPresent()) {
+                        LOGGER.debug("Table {}.{} is already added!", tableMetadata.getKeyspace(), tableMetadata.getName());
+                        return;
+                    }
+
+                    final java.util.function.Function<org.apache.cassandra.schema.KeyspaceMetadata, org.apache.cassandra.schema.KeyspaceMetadata> transformationFunction = ks -> ks
+                            .withSwapped(ks.tables.with(newCFMetaData));
+
+                    org.apache.cassandra.schema.KeyspaceMetadata transformed = transformationFunction.apply(current);
+
+                    Schema.instance.setKeyspaceMetadata(transformed);
+                    Schema.instance.load(newCFMetaData);
+
+                    LOGGER.info("Added schema for table {}", tableMetadata.asCQLQuery());
+                }
+                catch (Throwable t) {
+                    LOGGER.error(String.format("Error happend while adding table %s.%s", tableMetadata.getKeyspace(), tableMetadata.getName()), t);
+                }
+            }
+
+            @Override
+            public void onTableRemoved(final TableMetadata table) {
+                try {
+                    LOGGER.info(String.format("Table %s.%s detected to be removed!", table.getKeyspace().getName(), table.getName()));
+                    if (table.getOptions().isCDC()) {
+                        schemaHolder.removeTableSchema(new KeyspaceTable(table));
+                    }
+
+                    final String ksName = table.getKeyspace().getName();
+                    final String tableName = table.getName();
+
+                    final org.apache.cassandra.schema.KeyspaceMetadata oldKsm = Schema.instance.getKSMetaData(table.getKeyspace().getName());
+
+                    if (oldKsm == null) {
+                        LOGGER.warn("KeyspaceMetadata for keyspace {} is not found!", table.getKeyspace().getName());
+                        return;
+                    }
+
+                    final ColumnFamilyStore cfs = Keyspace.openWithoutSSTables(ksName).getColumnFamilyStore(tableName);
+
+                    if (cfs == null) {
+                        LOGGER.warn("ColumnFamilyStore for {}.{} is not found!", table.getKeyspace(), table.getName());
+                        return;
+                    }
+
+                    // make sure all the indexes are dropped, or else.
+                    cfs.indexManager.markAllIndexesRemoved();
+
+                    // reinitialize the keyspace.
+                    final CFMetaData cfm = oldKsm.tables.get(tableName).get();
+                    final org.apache.cassandra.schema.KeyspaceMetadata newKsm = oldKsm.withSwapped(oldKsm.tables.without(tableName));
+
+                    Schema.instance.unload(cfm);
+                    Schema.instance.setKeyspaceMetadata(newKsm);
+
+                    LOGGER.info("Removed schema for table {}", table.asCQLQuery());
+                }
+                catch (Throwable t) {
+                    LOGGER.error(String.format("Error happened while removing table %s.%s", table.getKeyspace(), table.getName()), t);
+                }
+            }
+
+            @Override
+            public void onTableChanged(final TableMetadata newTableMetadata, final TableMetadata oldTableMetaData) {
+                try {
+                    LOGGER.debug("Detected alternation in schema of {}.{} (previous cdc = {}, current cdc = {})",
+                            newTableMetadata.getKeyspace().getName(),
+                            newTableMetadata.getName(),
+                            oldTableMetaData.getOptions().isCDC(),
+                            newTableMetadata.getOptions().isCDC());
+
+                    if (newTableMetadata.getOptions().isCDC()) {
+                        // if it was cdc before and now it is too, add it, because its schema might change
+                        // however if it is CDC-enabled but it was not, update it in schema too because its cdc flag has changed
+                        // this basically means we add / update every time if new has cdc flag equals to true
+                        schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(newTableMetadata),
+                                new SchemaHolder.KeyValueSchema(kafkaTopicPrefix, newTableMetadata, sourceInfoStructMaker));
+                    }
+                    else if (oldTableMetaData.getOptions().isCDC()) {
+                        // if new table is not on cdc anymore, and we see the old one was, remove it
+                        schemaHolder.removeTableSchema(new KeyspaceTable(newTableMetadata));
+                    }
+
+                    // else if it was not cdc before nor now, do nothing with schema holder
+                    // but add it to Cassandra for subsequent deserialization path in every case
+
+                    final CFMetaData rawNewMetadata = CFMetaData.compile(newTableMetadata.asCQLQuery(),
+                            newTableMetadata.getKeyspace().getName());
+
+                    final CFMetaData oldMetadata = Schema.instance.getCFMetaData(oldTableMetaData.getKeyspace().getName(), oldTableMetaData.getName());
+
+                    // we need to copy because CFMetaData.compile will generate new cfId which would not match id of old metadata
+                    final CFMetaData newMetadata = rawNewMetadata.copy(oldMetadata.cfId);
+                    oldMetadata.apply(newMetadata);
+
+                    LOGGER.info("Updated schema for table {}", newTableMetadata.asCQLQuery());
+                }
+                catch (Throwable t) {
+                    LOGGER.error(String.format("Error happened while reacting on changed table %s.%s", newTableMetadata.getKeyspace(), newTableMetadata.getName()), t);
+                }
+            }
+        };
+    }
+
+    @Override
+    public void initialize() {
+        // populate schema holder when Debezium first starts
+        // because it would not be notified about that otherwise,
+        // listener is triggered on changes, not when driver connects for the first time
+        // so holder map would be empty
+        final Map<KeyspaceTable, SchemaHolder.KeyValueSchema> tables = schemaHolder.getCdcEnabledTableMetadataSet()
+                .stream()
+                .collect(toMap(KeyspaceTable::new,
+                        tableMetadata -> new SchemaHolder.KeyValueSchema(kafkaTopicPrefix, tableMetadata, sourceInfoStructMaker)));
+
+        tables.forEach(schemaHolder::addOrUpdateTableSchema);
+
+        LOGGER.info("Registering schema change listener ...");
+        cassandraClient.getCluster().register(schemaChangeListener);
     }
 
     @Override
     public void process() {
-        schemaHolder.refreshSchemas();
+        // intentionally empty as this processor is reactive in fact
+        // it is not querying what tables Cassandra has every n-seconds
+        // but it is notified by driver about these changes once they happen
+        // so there is nothing to do "periodically" as other processors do.
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.info("Unregistering schema change listener ...");
+        cassandraClient.getCluster().unregister(schemaChangeListener);
+        LOGGER.info("Clearing cdc keyspace / table map ... ");
+        schemaHolder.tableToKVSchemaMap.clear();
     }
 }

--- a/src/main/java/io/debezium/connector/cassandra/SnapshotProcessor.java
+++ b/src/main/java/io/debezium/connector/cassandra/SnapshotProcessor.java
@@ -198,7 +198,7 @@ public class SnapshotProcessor extends AbstractProcessor {
     private void processResultSet(TableMetadata tableMetadata, ResultSet resultSet) throws IOException {
         String tableName = tableName(tableMetadata);
         KeyspaceTable keyspaceTable = new KeyspaceTable(tableMetadata);
-        SchemaHolder.KeyValueSchema keyValueSchema = schemaHolder.getOrUpdateKeyValueSchema(keyspaceTable);
+        SchemaHolder.KeyValueSchema keyValueSchema = schemaHolder.getKeyValueSchema(keyspaceTable);
         Schema keySchema = keyValueSchema.keySchema();
         Schema valueSchema = keyValueSchema.valueSchema();
 

--- a/src/test/java/io/debezium/connector/cassandra/CommitLogProcessorTest.java
+++ b/src/test/java/io/debezium/connector/cassandra/CommitLogProcessorTest.java
@@ -29,11 +29,14 @@ import io.debezium.connector.base.ChangeEventQueue;
 public class CommitLogProcessorTest extends EmbeddedCassandraConnectorTestBase {
     private CassandraConnectorContext context;
     private CommitLogProcessor commitLogProcessor;
+    private SchemaProcessor schemaProcessor;
 
     @Before
     public void setUp() throws Exception {
         context = generateTaskContext();
         commitLogProcessor = new CommitLogProcessor(context);
+        schemaProcessor = new SchemaProcessor(context);
+        schemaProcessor.initialize();
         commitLogProcessor.initialize();
     }
 
@@ -41,6 +44,7 @@ public class CommitLogProcessorTest extends EmbeddedCassandraConnectorTestBase {
     public void tearDown() throws Exception {
         deleteTestOffsets(context);
         commitLogProcessor.destroy();
+        schemaProcessor.destroy();
         context.cleanUp();
     }
 
@@ -48,7 +52,6 @@ public class CommitLogProcessorTest extends EmbeddedCassandraConnectorTestBase {
     public void testProcessCommitLogs() throws Exception {
         int commitLogRowSize = 10;
         context.getCassandraClient().execute("CREATE TABLE IF NOT EXISTS " + keyspaceTable("cdc_table") + " (a int, b int, PRIMARY KEY(a)) WITH cdc = true;");
-        context.getSchemaHolder().refreshSchemas();
 
         // programmatically add insertion and deletion events into commit log, this is because running an 'INSERT' or 'DELETE'
         // cql against the embedded Cassandra does not modify the commit log file on disk.

--- a/src/test/java/io/debezium/connector/cassandra/SnapshotProcessorTest.java
+++ b/src/test/java/io/debezium/connector/cassandra/SnapshotProcessorTest.java
@@ -31,12 +31,13 @@ public class SnapshotProcessorTest extends EmbeddedCassandraConnectorTestBase {
     public void testSnapshotTable() throws Exception {
         CassandraConnectorContext context = generateTaskContext();
         SnapshotProcessor snapshotProcessor = Mockito.spy(new SnapshotProcessor(context));
+        SchemaProcessor schemaProcessor = new SchemaProcessor(context);
+        schemaProcessor.initialize();
         when(snapshotProcessor.isRunning()).thenReturn(true);
 
         int tableSize = 5;
         context.getCassandraClient().execute("CREATE TABLE IF NOT EXISTS " + keyspaceTable("cdc_table") + " (a int, b text, PRIMARY KEY(a)) WITH cdc = true;");
         context.getCassandraClient().execute("CREATE TABLE IF NOT EXISTS " + keyspaceTable("cdc_table2") + " (a int, b text, PRIMARY KEY(a)) WITH cdc = true;");
-        context.getSchemaHolder().refreshSchemas();
 
         for (int i = 0; i < tableSize; i++) {
             context.getCassandraClient().execute("INSERT INTO " + keyspaceTable("cdc_table") + "(a, b) VALUES (?, ?)", i, String.valueOf(i));
@@ -75,11 +76,12 @@ public class SnapshotProcessorTest extends EmbeddedCassandraConnectorTestBase {
     public void testSnapshotSkipsNonCdcEnabledTable() throws Exception {
         CassandraConnectorContext context = generateTaskContext();
         SnapshotProcessor snapshotProcessor = Mockito.spy(new SnapshotProcessor(context));
+        SchemaProcessor schemaProcessor = new SchemaProcessor(context);
+        schemaProcessor.initialize();
         when(snapshotProcessor.isRunning()).thenReturn(true);
 
         int tableSize = 5;
         context.getCassandraClient().execute("CREATE TABLE IF NOT EXISTS " + keyspaceTable("non_cdc_table") + " (a int, b text, PRIMARY KEY(a)) WITH cdc = false;");
-        context.getSchemaHolder().refreshSchemas();
         for (int i = 0; i < tableSize; i++) {
             context.getCassandraClient().execute("INSERT INTO " + keyspaceTable("non_cdc_table") + "(a, b) VALUES (?, ?)", i, String.valueOf(i));
         }
@@ -99,10 +101,11 @@ public class SnapshotProcessorTest extends EmbeddedCassandraConnectorTestBase {
         CassandraConnectorContext context = generateTaskContext();
         AtomicBoolean globalTaskState = new AtomicBoolean(true);
         SnapshotProcessor snapshotProcessor = Mockito.spy(new SnapshotProcessor(context));
+        SchemaProcessor schemaProcessor = new SchemaProcessor(context);
+        schemaProcessor.initialize();
         when(snapshotProcessor.isRunning()).thenReturn(true);
 
         context.getCassandraClient().execute("CREATE TABLE IF NOT EXISTS " + keyspaceTable("cdc_table") + " (a int, b text, PRIMARY KEY(a)) WITH cdc = true;");
-        context.getSchemaHolder().refreshSchemas();
 
         ChangeEventQueue<Event> queue = context.getQueues().get(0);
         assertEquals(queue.totalCapacity(), queue.remainingCapacity());


### PR DESCRIPTION
Hi @gunnarmorling / @bingqinzhou 

we wanted to use your connector (and we still do) but we found couple critical issues with the current solution you are providing which renders this connector not fully suitable to production needs.

The problem we are seeing is quite hard to grasp and fully explain so I prepared two "readmes" here

part 1: this is our original attempt to solve it (1)
part 2: this is rewritten part 1 because we identified that the solution in part 1 is not enough (2)

We are providing the "part 2" solution in this PR.

We know this is quite big change but without it we are very hesitant to use it and our customers would find it very hard to use - if not impossible. We have our fix internally but we want this change to happen in upstream too for a greater good as well as to not balkanize this space with custom modifications.

It would be very nice if you could give us a constructive feedback on what we did and eventually we might cooperate to have this merged in your main branch. I am here to fully cooperate.

Please keep in mind that this serves as a basic building block to move this forward and open more deeper discussion about it.

1) https://github.com/debezium/debezium-connector-cassandra/blob/ac43b7797c084c3e67cedde3662af1e58de8a4c2/REPORT.adoc
2) https://github.com/debezium/debezium-connector-cassandra/blob/ac43b7797c084c3e67cedde3662af1e58de8a4c2/REPORT_2.adoc

Regards, Stefan

EDIT:

this has DDD-2 where reports were consolidated https://github.com/debezium/debezium-design-documents/pull/2