### PR TITLE
[DBZ-3590]: Change valueSchema name to be Envelope.

### DIFF
--- a/src/main/java/io/debezium/connector/cassandra/KeyValueSchema.java
+++ b/src/main/java/io/debezium/connector/cassandra/KeyValueSchema.java
@@ -78,7 +78,7 @@ public class KeyValueSchema {
     }
 
     private static String getValueName(String kafkaTopicPrefix, TableMetadata tm) {
-        return kafkaTopicPrefix + "." + tm.getKeyspace().getName() + "." + tm.getName() + ".Value";
+        return kafkaTopicPrefix + "." + tm.getKeyspace().getName() + "." + tm.getName() + ".Envelope";
     }
 
     /**


### PR DESCRIPTION
Change the Kafka value of change event from Cassandra Connector to be name with `Envelope` suffix.

https://issues.redhat.com/projects/DBZ/issues/DBZ-3590