### PR TITLE
DBZ-2251 add validation to make two configs required

### DIFF
--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.storage.Converter;
 import com.datastax.driver.core.ConsistencyLevel;
 
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.AbstractSourceInfo;
@@ -289,6 +290,17 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
     public static final boolean DEFAULT_TOMBSTONES_ON_DELETE = false;
 
     protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 0;
+
+    private static final ConfigDefinition CONFIG_DEFINITION = CommonConnectorConfig.CONFIG_DEFINITION.edit()
+            .name("cassandra")
+            .type(
+                    COMMIT_LOG_RELOCATION_DIR,
+                    OFFSET_BACKING_STORE_DIR,
+                    SCHEMA_POLL_INTERVAL_MS,
+                    SNAPSHOT_POLL_INTERVAL_MS)
+            .create();
+
+    public static Field.Set ALL_FIELDS = Field.setOf(CONFIG_DEFINITION.all());
 
     public CassandraConnectorConfig(Configuration config) {
         super(config, config.getString(CONNECTOR_NAME), DEFAULT_SNAPSHOT_FETCH_SIZE);

--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -160,6 +160,7 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
 
     public static final Field COMMIT_LOG_RELOCATION_DIR = Field.create("commit.log.relocation.dir")
             .withType(Type.STRING)
+            .withValidation(Field::isRequired)
             .withDescription("The local directory which commit logs get relocated to once processed.");
 
     /**
@@ -191,6 +192,7 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
 
     public static final Field OFFSET_BACKING_STORE_DIR = Field.create("offset.backing.store.dir")
             .withType(Type.STRING)
+            .withValidation(Field::isRequired)
             .withDescription("The directory which is used to store offset tracking files.");
 
     /**

--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -201,7 +201,7 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
     public static final int DEFAULT_OFFSET_FLUSH_INTERVAL_MS = 0;
     public static final Field OFFSET_FLUSH_INTERVAL_MS = Field.create("offset.flush.interval.ms")
             .withType(Type.INT)
-            .withDefault(0)
+            .withDefault(DEFAULT_OFFSET_FLUSH_INTERVAL_MS)
             .withDescription("The minimum amount of time to wait before committing the offset, given in milliseconds. Defaults 0 ms.");
 
     /**
@@ -216,7 +216,7 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
     public static final int DEFAULT_SCHEMA_POLL_INTERVAL_MS = 10_000;
     public static final Field SCHEMA_POLL_INTERVAL_MS = Field.create("schema.refresh.interval.ms")
             .withType(Type.INT)
-            .withDefault(10_000)
+            .withDefault(DEFAULT_SCHEMA_POLL_INTERVAL_MS)
             .withValidation(Field::isPositiveInteger)
             .withDescription(
                     "Interval for the schema processor to wait before refreshing the cached Cassandra table schemas, given in milliseconds. Defaults to 10 seconds (10,000 ms).");
@@ -224,13 +224,13 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
     public static final int DEFAULT_CDC_DIR_POLL_INTERVAL_MS = 10_000;
     public static final Field CDC_DIR_POLL_INTERVAL_MS = Field.create("cdc.dir.poll.interval.ms")
             .withType(Type.INT)
-            .withDefault(10_000)
+            .withDefault(DEFAULT_CDC_DIR_POLL_INTERVAL_MS)
             .withDescription("The maximum amount of time to wait on each poll before re-attempt, given in milliseconds. Defaults to 10 seconds (10,000 ms).");
 
     public static final int DEFAULT_SNAPSHOT_POLL_INTERVAL_MS = 10_000;
     public static final Field SNAPSHOT_POLL_INTERVAL_MS = Field.create("snapshot.scan.interval.ms")
             .withType(Type.INT)
-            .withDefault(10_000)
+            .withDefault(DEFAULT_SNAPSHOT_POLL_INTERVAL_MS)
             .withValidation(Field::isPositiveInteger)
             .withDescription(
                     "Interval for the snapshot processor to wait before re-scanning tables to look for new cdc-enabled tables. Defaults to 10 seconds (10,000 ms).");
@@ -238,7 +238,7 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
     public static final int DEFAULT_COMMIT_LOG_RELOCATION_DIR_POLL_INTERVAL_MS = 10_000;
     public static final Field COMMIT_LOG_RELOCATION_DIR_POLL_INTERVAL_MS = Field.create("commit.log.relocation.dir.poll.interval.ms")
             .withType(Type.INT)
-            .withDefault(10_000)
+            .withDefault(DEFAULT_COMMIT_LOG_RELOCATION_DIR_POLL_INTERVAL_MS)
             .withDescription(
                     "The amount of time the CommitLogPostProcessor should wait to re-fetch all commitLog files in relocation dir, given in milliseconds. Defaults to 10 seconds (10,000 ms).");
 

--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.cassandra;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -24,7 +25,6 @@ import org.apache.kafka.connect.storage.Converter;
 import com.datastax.driver.core.ConsistencyLevel;
 
 import io.debezium.config.CommonConnectorConfig;
-import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.AbstractSourceInfo;
@@ -291,16 +291,10 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
 
     protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 0;
 
-    private static final ConfigDefinition CONFIG_DEFINITION = CommonConnectorConfig.CONFIG_DEFINITION.edit()
-            .name("cassandra")
-            .type(
-                    COMMIT_LOG_RELOCATION_DIR,
-                    OFFSET_BACKING_STORE_DIR,
-                    SCHEMA_POLL_INTERVAL_MS,
-                    SNAPSHOT_POLL_INTERVAL_MS)
-            .create();
+    public static List<Field> validationFieldList = new ArrayList<>(
+            Arrays.asList(OFFSET_BACKING_STORE_DIR, COMMIT_LOG_RELOCATION_DIR, SCHEMA_POLL_INTERVAL_MS, SNAPSHOT_POLL_INTERVAL_MS));
 
-    public static Field.Set ALL_FIELDS = Field.setOf(CONFIG_DEFINITION.all());
+    public static Field.Set VALIDATION_FIELDS = Field.setOf(validationFieldList);
 
     public CassandraConnectorConfig(Configuration config) {
         super(config, config.getString(CONNECTOR_NAME), DEFAULT_SNAPSHOT_FETCH_SIZE);

--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
@@ -70,6 +70,11 @@ public class CassandraConnectorTask {
 
     void run() throws Exception {
         try {
+            if (!config.validateAndRecord(config.ALL_FIELDS, LOGGER::error)) {
+                LOGGER.error("Failed to start connector with invalid configuration (see logs for actual errors)");
+                return;
+            }
+
             LOGGER.info("Initializing Cassandra connector task context ...");
             taskContext = new CassandraConnectorContext(config);
 

--- a/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
+++ b/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
@@ -70,9 +70,9 @@ public class CassandraConnectorTask {
 
     void run() throws Exception {
         try {
-            if (!config.validateAndRecord(config.ALL_FIELDS, LOGGER::error)) {
-                LOGGER.error("Failed to start connector with invalid configuration (see logs for actual errors)");
-                return;
+            if (!config.validateAndRecord(config.VALIDATION_FIELDS, LOGGER::error)) {
+                throw new CassandraConnectorConfigException("Failed to start connector with invalid configuration " +
+                        "(see logs for actual errors)");
             }
 
             LOGGER.info("Initializing Cassandra connector task context ...");


### PR DESCRIPTION
Add validation to make sure the following two configs are not null:
`commit.log.relocation.dir`
`offset.backing.store.dir`