### PR TITLE
DBZ-4839

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ You are encouraged to explore this connector and test it, but it is not recommen
 
 Please see the [README.md](https://github.com/debezium/debezium#building-debezium) in the main repository for general instructions on building Debezium from source (prerequisites, usage of Docker etc).
 
+## Cassandra compatibility
+
+The following table list supported version of Apache Cassandra:
+
+
+| Connector version | Apache Cassandra  |
+|--|---|
+| 1.9+ | 3.11  | 
 ## Building the Cassandra 3.x connector
 
 Building this connector first requires the main [debezium](https://github.com/debezium/debezium) code repository to be built locally using `mvn clean install`.

--- a/README.md
+++ b/README.md
@@ -25,26 +25,14 @@ The following table list supported version of Apache Cassandra:
 
 | Connector version | Apache Cassandra  |
 |--|---|
-| 1.9+ | 3.11  | 
-## Building the Cassandra 3.x connector
+| 1.9+ | Compatible with 3.x and 4.x version  |
+| Up to 1.8 | Compatible with only 3.x  |
+## Building the Cassandra connector
 
-Building this connector first requires the main [debezium](https://github.com/debezium/debezium) code repository to be built locally using `mvn clean install`.
-
-In order to build the Cassandra connector you'll need JDK 8 because Cassandra 3.x
-doesn't support Java versions above Java 8. That also means dependencies like
-`debezium-core` have to be built as Java 8 bytecode version 52.0 as well,
-either by compiling it with Java 8 or specifying Java 8 bytecode generation
-on newer versions of Java.
-
-Then the Cassandra connector can be built like so:
+The Cassandra connector can be built like so:
 
     $ mvn clean install
     
-If you have multiple Java installation on your machine you can select the correct
-version by setting JAVA_HOME env var:
-
-    $ JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 mvn clean install
-
 ### Building just the artifacts, without running tests, CheckStyle, etc.
 
 You can skip all non-essential plug-ins (tests, integration tests, CheckStyle, formatter, API compatibility check, etc.) using the "quick" build profile:


### PR DESCRIPTION
With this new PR related to DBZ-4839, we will update the readme to notice that:
DBZ will be compatible Cassandra 4.x from 1.9
Building the project does not require the main DBZ repo
We no longer limited to java-8, the new version works with java-11