### PR TITLE
DBZ-4401 Support partition key row deletion and range tombstone row types

### DIFF
--- a/cassandra-3/src/main/java/io/debezium/connector/cassandra/Cassandra3SchemaChangeListener.java
+++ b/cassandra-3/src/main/java/io/debezium/connector/cassandra/Cassandra3SchemaChangeListener.java
@@ -43,7 +43,7 @@ public class Cassandra3SchemaChangeListener extends AbstractSchemaChangeListener
         LOGGER.info("Initializing SchemaHolder ...");
         List<TableMetadata> cdcEnabledTableMetadataList = getCdcEnabledTableMetadataList(session);
         for (com.datastax.oss.driver.api.core.metadata.schema.TableMetadata tm : cdcEnabledTableMetadataList) {
-            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(tm), new KeyValueSchema(this.kafkaTopicPrefix, tm, this.sourceInfoStructMaker));
+            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(tm), getKeyValueSchema(tm));
             onKeyspaceCreated(session.getMetadata().getKeyspace(tm.getKeyspace().toString()).get());
             onTableCreated(tm);
         }
@@ -103,8 +103,7 @@ public class Cassandra3SchemaChangeListener extends AbstractSchemaChangeListener
         boolean cdcEnabled = cdc.toString().equals("true");
 
         if (cdcEnabled) {
-            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(tableMetadata),
-                    new KeyValueSchema(kafkaTopicPrefix, tableMetadata, sourceInfoStructMaker));
+            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(tableMetadata), getKeyValueSchema(tableMetadata));
         }
         try {
             LOGGER.debug("Table {}.{} detected to be added!", tableMetadata.getKeyspace(), tableMetadata.getName());
@@ -204,8 +203,7 @@ public class Cassandra3SchemaChangeListener extends AbstractSchemaChangeListener
             // if it was cdc before and now it is too, add it, because its schema might change
             // however if it is CDC-enabled but it was not, update it in schema too because its cdc flag has changed
             // this basically means we add / update every time if new has cdc flag equals to true
-            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(newTableMetadata),
-                    new KeyValueSchema(kafkaTopicPrefix, newTableMetadata, sourceInfoStructMaker));
+            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(newTableMetadata), getKeyValueSchema(newTableMetadata));
         }
         else if (oldCdc) {
             // if new table is not on cdc anymore, and we see the old one was, remove it

--- a/cassandra-4/src/main/java/io/debezium/connector/cassandra/Cassandra4SchemaChangeListener.java
+++ b/cassandra-4/src/main/java/io/debezium/connector/cassandra/Cassandra4SchemaChangeListener.java
@@ -45,7 +45,7 @@ public class Cassandra4SchemaChangeListener extends AbstractSchemaChangeListener
         LOGGER.info("Initializing SchemaHolder ...");
         List<com.datastax.oss.driver.api.core.metadata.schema.TableMetadata> cdcEnabledTableMetadataList = getCdcEnabledTableMetadataList(session);
         for (com.datastax.oss.driver.api.core.metadata.schema.TableMetadata tm : cdcEnabledTableMetadataList) {
-            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(tm), new KeyValueSchema(this.kafkaTopicPrefix, tm, this.sourceInfoStructMaker));
+            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(tm), getKeyValueSchema(tm));
             onKeyspaceCreated(session.getMetadata().getKeyspace(tm.getKeyspace().toString()).get());
             onTableCreated(tm);
         }
@@ -105,8 +105,7 @@ public class Cassandra4SchemaChangeListener extends AbstractSchemaChangeListener
         boolean cdcEnabled = cdc.toString().equals("true");
 
         if (cdcEnabled) {
-            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(tableMetadata),
-                    new KeyValueSchema(kafkaTopicPrefix, tableMetadata, sourceInfoStructMaker));
+            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(tableMetadata), getKeyValueSchema(tableMetadata));
         }
         try {
             LOGGER.info("Table {}.{} detected to be added!", tableMetadata.getKeyspace(), tableMetadata.getName());
@@ -221,8 +220,7 @@ public class Cassandra4SchemaChangeListener extends AbstractSchemaChangeListener
             // if it was cdc before and now it is too, add it, because its schema might change
             // however if it is CDC-enabled but it was not, update it in schema too because its cdc flag has changed
             // this basically means we add / update every time if new has cdc flag equals to true
-            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(newTableMetadata),
-                    new KeyValueSchema(kafkaTopicPrefix, newTableMetadata, sourceInfoStructMaker));
+            schemaHolder.addOrUpdateTableSchema(new KeyspaceTable(newTableMetadata), getKeyValueSchema(newTableMetadata));
         }
         else if (oldCdc) {
             // if new table is not on cdc anymore, and we see the old one was, remove it

--- a/cassandra-4/src/test/java/io/debezium/connector/cassandra/ClusteringPartitionKeyCommitLogProcessingTest.java
+++ b/cassandra-4/src/test/java/io/debezium/connector/cassandra/ClusteringPartitionKeyCommitLogProcessingTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.deleteFrom;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal;
+import static io.debezium.connector.cassandra.Event.EventType.CHANGE_EVENT;
+import static io.debezium.connector.cassandra.Record.Operation.DELETE;
+import static io.debezium.connector.cassandra.Record.Operation.INSERT;
+import static io.debezium.connector.cassandra.TestUtils.TEST_KEYSPACE_NAME;
+import static io.debezium.connector.cassandra.TestUtils.runCql;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+public class ClusteringPartitionKeyCommitLogProcessingTest extends AbstractCommitLogProcessorTest {
+
+    @Override
+    public void initialiseData() {
+        createTable("CREATE TABLE IF NOT EXISTS %s.%s (a int, b int, c int, PRIMARY KEY ((a), b)) WITH cdc = true;");
+
+        runCql(insertInto(TEST_KEYSPACE_NAME, tableName)
+                .value("a", literal(1))
+                .value("b", literal(1))
+                .value("c", literal(1))
+                .build());
+
+        runCql(insertInto(TEST_KEYSPACE_NAME, tableName)
+                .value("a", literal(1))
+                .value("b", literal(2))
+                .value("c", literal(3))
+                .build());
+
+        runCql(deleteFrom(TEST_KEYSPACE_NAME, tableName).whereColumn("a").isEqualTo(literal(1)).build());
+    }
+
+    @Override
+    public void verifyEvents() throws Exception {
+        List<Event> events = getEvents();
+
+        Record insert1 = (Record) events.get(0);
+        assertEquals(insert1.getEventType(), CHANGE_EVENT);
+        assertEquals(INSERT, insert1.getOp());
+
+        Record insert2 = (Record) events.get(1);
+        assertEquals(insert2.getEventType(), CHANGE_EVENT);
+        assertEquals(INSERT, insert2.getOp());
+
+        Record delete = (Record) events.get(2);
+        assertEquals(delete.getEventType(), CHANGE_EVENT);
+        assertEquals(DELETE, delete.getOp());
+    }
+}

--- a/cassandra-4/src/test/java/io/debezium/connector/cassandra/QueueProcessorTest.java
+++ b/cassandra-4/src/test/java/io/debezium/connector/cassandra/QueueProcessorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra;
+
+import static com.datastax.oss.driver.api.core.type.DataTypes.INT;
+import static com.datastax.oss.driver.api.core.type.DataTypes.TEXT;
+import static io.debezium.connector.cassandra.CellData.ColumnType.CLUSTERING;
+import static io.debezium.connector.cassandra.CellData.ColumnType.PARTITION;
+import static io.debezium.connector.cassandra.CellData.ColumnType.REGULAR;
+import static io.debezium.connector.cassandra.KeyValueSchema.getPrimaryKeySchemas;
+import static io.debezium.connector.cassandra.Record.Operation.INSERT;
+import static io.debezium.connector.cassandra.Record.Operation.RANGE_TOMBSTONE;
+import static io.debezium.connector.cassandra.RowData.rowSchema;
+import static io.debezium.connector.cassandra.TestUtils.TEST_KEYSPACE_NAME;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.cassandra.transforms.CassandraTypeDeserializer;
+import io.debezium.connector.cassandra.transforms.DebeziumTypeDeserializer;
+import io.debezium.time.Conversions;
+
+public class QueueProcessorTest {
+    private CassandraConnectorContext context;
+    private QueueProcessor queueProcessor;
+    private TestingKafkaRecordEmitter emitter;
+    private KeyValueSchema keyValueSchema;
+    private RowData rowData;
+    private SourceInfo sourceInfo;
+
+    @Before
+    public void setUp() throws Exception {
+        context = generateTaskContext(Configuration.from(TestUtils.generateDefaultConfigMap()));
+        emitter = new TestingKafkaRecordEmitter(
+                context.getCassandraConnectorConfig().kafkaTopicPrefix(),
+                context.getCassandraConnectorConfig().getHeartbeatTopicsPrefix(),
+                context.getKafkaProducer(),
+                context.getOffsetWriter(),
+                context.getCassandraConnectorConfig().offsetFlushIntervalMs(),
+                context.getCassandraConnectorConfig().maxOffsetFlushSize(),
+                context.getCassandraConnectorConfig().getKeyConverter(),
+                context.getCassandraConnectorConfig().getValueConverter(),
+                context.getErroneousCommitLogs(),
+                context.getCassandraConnectorConfig().getCommitLogTransfer());
+
+        queueProcessor = new QueueProcessor(context, 0, emitter);
+
+        keyValueSchema = new KeyValueSchema.KeyValueSchemaBuilder()
+                .withKeyspace(TEST_KEYSPACE_NAME)
+                .withTable("cdc_table")
+                .withKafkaTopicPrefix(context.getCassandraConnectorConfig().kafkaTopicPrefix())
+                .withSourceInfoStructMarker(context.getCassandraConnectorConfig().getSourceInfoStructMaker())
+                .withRowSchema(rowSchema(asList("col1", "col2"), asList(TEXT, INT)))
+                .withPrimaryKeyNames(asList("p1", "c1"))
+                .withPrimaryKeySchemas(getPrimaryKeySchemas(asList(INT, INT)))
+                .build();
+
+        rowData = new RowData();
+        rowData.addCell(new CellData("p1", 1, null, PARTITION));
+        rowData.addCell(new CellData("c1", 2, null, CLUSTERING));
+        rowData.addCell(new CellData("col1", "col1value", null, REGULAR));
+        rowData.addCell(new CellData("col2", 3, null, REGULAR));
+
+        sourceInfo = new SourceInfo(context.getCassandraConnectorConfig(), "cluster1",
+                new OffsetPosition("CommitLog-6-123.log", 0),
+                new KeyspaceTable(TEST_KEYSPACE_NAME, "cdc_table"), false,
+                Conversions.toInstantFromMicros(System.currentTimeMillis() * 1000));
+    }
+
+    @After
+    public void tearDown() {
+        context.cleanUp();
+    }
+
+    @Test
+    public void testInsertChangeRecordProcessing() throws Exception {
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
+        Record record = new ChangeRecord(sourceInfo, rowData, keyValueSchema.keySchema(),
+                keyValueSchema.valueSchema(), INSERT, false);
+
+        queue.enqueue(record);
+
+        assertEquals(1, queue.totalCapacity() - queue.remainingCapacity());
+
+        queueProcessor.process();
+
+        assertEquals(1, emitter.records.size());
+        assertEquals(queue.totalCapacity(), queue.remainingCapacity());
+    }
+
+    @Test
+    public void testRangeTombstoneChangeRecordProcessing() throws Exception {
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
+
+        rowData.addStart("1");
+        rowData.addEnd("2");
+
+        Record record = new ChangeRecord(sourceInfo, rowData, keyValueSchema.keySchema(),
+                keyValueSchema.valueSchema(), RANGE_TOMBSTONE, false);
+
+        queue.enqueue(record);
+
+        assertEquals(1, queue.totalCapacity() - queue.remainingCapacity());
+
+        queueProcessor.process();
+
+        assertEquals(1, emitter.records.size());
+        assertEquals(queue.totalCapacity(), queue.remainingCapacity());
+    }
+
+    @Test
+    public void testProcessTombstoneRecords() throws Exception {
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
+        Record record = new TombstoneRecord(sourceInfo, rowData, keyValueSchema.keySchema());
+
+        queue.enqueue(record);
+
+        assertEquals(1, queue.totalCapacity() - queue.remainingCapacity());
+
+        queueProcessor.process();
+
+        assertEquals(1, emitter.records.size());
+        assertEquals(queue.totalCapacity(), queue.remainingCapacity());
+    }
+
+    @Test
+    public void testProcessEofEvent() throws Exception {
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
+        File commitLogFile = TestUtils.generateCommitLogFile();
+        queue.enqueue(new EOFEvent(commitLogFile));
+
+        assertEquals(1, queue.totalCapacity() - queue.remainingCapacity());
+        queueProcessor.process();
+        assertEquals(0, emitter.records.size());
+        assertEquals(queue.totalCapacity(), queue.remainingCapacity());
+    }
+
+    private CassandraConnectorContext generateTaskContext(Configuration configuration) throws Exception {
+
+        CassandraTypeDeserializer.init(new DebeziumTypeDeserializer() {
+            @Override
+            public Object deserialize(AbstractType abstractType, ByteBuffer bb) {
+                return abstractType.getSerializer().deserialize(bb);
+            }
+        });
+
+        return new CassandraConnectorContext(new CassandraConnectorConfig(configuration));
+    }
+}

--- a/cassandra-4/src/test/java/io/debezium/connector/cassandra/RangeTombstoneCommitLogProcessingTest.java
+++ b/cassandra-4/src/test/java/io/debezium/connector/cassandra/RangeTombstoneCommitLogProcessingTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.deleteFrom;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal;
+import static io.debezium.connector.cassandra.Event.EventType.CHANGE_EVENT;
+import static io.debezium.connector.cassandra.Record.Operation.INSERT;
+import static io.debezium.connector.cassandra.Record.Operation.RANGE_TOMBSTONE;
+import static io.debezium.connector.cassandra.TestUtils.TEST_KEYSPACE_NAME;
+import static io.debezium.connector.cassandra.TestUtils.runCql;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+public class RangeTombstoneCommitLogProcessingTest extends AbstractCommitLogProcessorTest {
+
+    @Override
+    public void initialiseData() {
+        createTable("CREATE TABLE IF NOT EXISTS %s.%s (a int, b int, c int, d int, e int, PRIMARY KEY (a,b,c,d)) WITH cdc = true;");
+
+        // INSERT INTO test_keyspace.table_name (a, b, c, d, e) VALUES (1, 1, 1, 1, 1);
+        runCql(insertInto(TEST_KEYSPACE_NAME, tableName)
+                .value("a", literal(1))
+                .value("b", literal(1))
+                .value("c", literal(1))
+                .value("d", literal(1))
+                .value("e", literal(1))
+                .build());
+
+        // INSERT INTO test_keyspace.table_name (a, b, c, d, e) VALUES (1, 1, 2, 3, 2);
+        runCql(insertInto(TEST_KEYSPACE_NAME, tableName)
+                .value("a", literal(1))
+                .value("b", literal(1))
+                .value("c", literal(2))
+                .value("d", literal(3))
+                .value("e", literal(2))
+                .build());
+
+        // "DELETE FROM ks.tb WHERE a = 1 AND b = 1 AND c <= 2";
+        runCql(deleteFrom(TEST_KEYSPACE_NAME, tableName)
+                .whereColumn("a").isEqualTo(literal(1))
+                .whereColumn("b").isEqualTo(literal(1))
+                .whereColumn("c").isLessThanOrEqualTo(literal(2))
+                .build());
+    }
+
+    @Override
+    public void verifyEvents() throws Exception {
+        List<Event> events = getEvents();
+
+        assertEquals(3, events.size());
+
+        Record insert = (Record) events.get(0);
+        assertEquals(insert.getEventType(), CHANGE_EVENT);
+        assertEquals(INSERT, insert.getOp());
+
+        Record insert2 = (Record) events.get(1);
+        assertEquals(insert2.getEventType(), CHANGE_EVENT);
+        assertEquals(INSERT, insert2.getOp());
+
+        Record range1 = (Record) events.get(2);
+        assertEquals(range1.getEventType(), CHANGE_EVENT);
+        assertEquals(RANGE_TOMBSTONE, range1.getOp());
+        assertEquals("INCL_START_BOUND(1)", range1.getRowData().getStart());
+        assertEquals("INCL_END_BOUND(1, 2)", range1.getRowData().getEnd());
+    }
+}

--- a/core/src/main/java/io/debezium/connector/cassandra/AbstractSchemaChangeListener.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/AbstractSchemaChangeListener.java
@@ -42,4 +42,15 @@ public class AbstractSchemaChangeListener extends SchemaChangeListenerBase {
     public SchemaHolder getSchemaHolder() {
         return schemaHolder;
     }
+
+    protected KeyValueSchema getKeyValueSchema(TableMetadata tm) {
+        return new KeyValueSchema.KeyValueSchemaBuilder()
+                .withTableMetadata(tm)
+                .withKafkaTopicPrefix(kafkaTopicPrefix)
+                .withPrimaryKeyNames(KeyValueSchema.getPrimaryKeyNames(tm))
+                .withPrimaryKeySchemas(KeyValueSchema.getPrimaryKeySchemas(tm))
+                .withSourceInfoStructMarker(sourceInfoStructMaker)
+                .withRowSchema(RowData.rowSchema(tm))
+                .build();
+    }
 }

--- a/core/src/main/java/io/debezium/connector/cassandra/CellData.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CellData.java
@@ -7,17 +7,12 @@ package io.debezium.connector.cassandra;
 
 import java.util.Objects;
 
-import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
-import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
-
 import io.debezium.DebeziumException;
-import io.debezium.connector.cassandra.transforms.CassandraTypeConverter;
-import io.debezium.connector.cassandra.transforms.CassandraTypeDeserializer;
 
 /**
  * Cell-level data about the source event. Each cell contains the name, value and
@@ -70,33 +65,29 @@ public class CellData implements KafkaRecord {
     @Override
     public Struct record(Schema schema) {
         try {
-            Struct cellStruct = new Struct(schema)
+            return new Struct(schema)
                     .put(CELL_DELETION_TS_KEY, deletionTs)
                     .put(CELL_SET_KEY, true)
                     .put(CELL_VALUE_KEY, value);
-            return cellStruct;
         }
         catch (DataException e) {
             throw new DebeziumException(String.format("Failed to record Cell. Name: %s, Schema: %s, Value: %s", name, schema.toString(), value), e);
         }
     }
 
-    static Schema cellSchema(ColumnMetadata cm, boolean optional) {
-        AbstractType<?> convertedType = CassandraTypeConverter.convert(cm.getType());
-        Schema valueSchema = CassandraTypeDeserializer.getSchemaBuilder(convertedType).build();
-        if (valueSchema != null) {
-            SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(cm.getName().toString())
-                    .field(CELL_VALUE_KEY, valueSchema)
-                    .field(CELL_DELETION_TS_KEY, Schema.OPTIONAL_INT64_SCHEMA)
-                    .field(CELL_SET_KEY, Schema.BOOLEAN_SCHEMA);
-            if (optional) {
-                schemaBuilder.optional();
-            }
-            return schemaBuilder.build();
-        }
-        else {
+    static Schema cellSchema(String columnName, Schema columnSchema, boolean optional) {
+        if (columnSchema == null) {
             return null;
         }
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(columnName)
+                .field(CELL_VALUE_KEY, columnSchema)
+                .field(CELL_DELETION_TS_KEY, Schema.OPTIONAL_INT64_SCHEMA)
+                .field(CELL_SET_KEY, Schema.BOOLEAN_SCHEMA);
+        if (optional) {
+            schemaBuilder.optional();
+        }
+        return schemaBuilder.build();
     }
 
     @Override

--- a/core/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CommitLogUtil.java
@@ -44,8 +44,10 @@ public final class CommitLogUtil {
                 LOGGER.warn("Cannot move file {} because it does not appear to be a CommitLog.", file.toAbsolutePath());
                 return;
             }
-            Files.move(file, toDir.resolve(file.getFileName()), REPLACE_EXISTING);
-            LOGGER.info("Moved CommitLog file {} to {}.", file, toDir);
+            if (Files.exists(file)) {
+                Files.move(file, toDir.resolve(file.getFileName()), REPLACE_EXISTING);
+                LOGGER.info("Moved CommitLog file {} to {}.", file, toDir);
+            }
         }
         catch (Exception ex) {
             LOGGER.warn("Failed to move CommitLog file {} to {}. Error:", file.getFileName().toString(), toDir, ex);

--- a/core/src/main/java/io/debezium/connector/cassandra/Emitter.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/Emitter.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra;
+
+public interface Emitter extends AutoCloseable {
+    void emit(Record record);
+}

--- a/core/src/main/java/io/debezium/connector/cassandra/KeyValueSchema.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/KeyValueSchema.java
@@ -5,12 +5,15 @@
  */
 package io.debezium.connector.cassandra;
 
-import org.apache.cassandra.db.marshal.AbstractType;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+import com.datastax.oss.driver.api.core.type.DataType;
 
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.connector.cassandra.exceptions.CassandraConnectorSchemaException;
@@ -22,16 +25,160 @@ import io.debezium.connector.cassandra.transforms.CassandraTypeDeserializer;
  */
 public class KeyValueSchema {
 
-    private static final String NAMESPACE = "io.debezium.connector.cassandra";
-
     private final TableMetadata tableMetadata;
     private final Schema keySchema;
     private final Schema valueSchema;
 
-    KeyValueSchema(String kafkaTopicPrefix, TableMetadata tableMetadata, SourceInfoStructMaker sourceInfoStructMaker) {
+    KeyValueSchema(TableMetadata tableMetadata, Schema keySchema, Schema valueSchema) {
         this.tableMetadata = tableMetadata;
-        this.keySchema = getKeySchema(kafkaTopicPrefix, tableMetadata);
-        this.valueSchema = getValueSchema(kafkaTopicPrefix, tableMetadata, sourceInfoStructMaker);
+        this.keySchema = keySchema;
+        this.valueSchema = valueSchema;
+    }
+
+    public static class KeyValueSchemaBuilder {
+        private static String NAMESPACE = "io.debezium.connector.cassandra";
+        private String keyspace;
+        private String table;
+        private TableMetadata tableMetadata;
+        private String kafkaTopicPrefix;
+        private SourceInfoStructMaker sourceInfoStructMaker;
+        private List<String> primaryKeyNames;
+        private List<Schema> primaryKeySchemas;
+        private Schema rowSchema;
+
+        public KeyValueSchemaBuilder withKeyspace(String keyspace) {
+            this.keyspace = keyspace;
+            return this;
+        }
+
+        public KeyValueSchemaBuilder withTable(String table) {
+            this.table = table;
+            return this;
+        }
+
+        public KeyValueSchemaBuilder withKafkaTopicPrefix(String kafkaTopicPrefix) {
+            this.kafkaTopicPrefix = kafkaTopicPrefix;
+            return this;
+        }
+
+        public KeyValueSchemaBuilder withSourceInfoStructMarker(SourceInfoStructMaker sourceInfoStructMarker) {
+            this.sourceInfoStructMaker = sourceInfoStructMarker;
+            return this;
+        }
+
+        public KeyValueSchemaBuilder withPrimaryKeyNames(List<String> primaryKeyNames) {
+            this.primaryKeyNames = primaryKeyNames;
+            return this;
+        }
+
+        public KeyValueSchemaBuilder withPrimaryKeySchemas(List<Schema> primaryKeySchemas) {
+            this.primaryKeySchemas = primaryKeySchemas;
+            return this;
+        }
+
+        public KeyValueSchemaBuilder withRowSchema(Schema rowSchema) {
+            this.rowSchema = rowSchema;
+            return this;
+        }
+
+        public KeyValueSchemaBuilder withTableMetadata(TableMetadata tableMetadata) {
+            if (tableMetadata != null) {
+                this.tableMetadata = tableMetadata;
+                this.keyspace = this.tableMetadata.getKeyspace().toString();
+                this.table = this.tableMetadata.getName().toString();
+            }
+            return this;
+        }
+
+        private String getKeyName() {
+            return kafkaTopicPrefix + "." + keyspace + "." + table + ".Key";
+        }
+
+        private String getValueName() {
+            return kafkaTopicPrefix + "." + keyspace + "." + table + ".Envelope";
+        }
+
+        private Schema getKeySchema() {
+            SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(NAMESPACE + "." + getKeyName());
+
+            for (int i = 0; i < primaryKeyNames.size(); i++) {
+                schemaBuilder.field(primaryKeyNames.get(i), primaryKeySchemas.get(i));
+            }
+
+            return schemaBuilder.build();
+        }
+
+        private Schema getValueSchema() {
+            return SchemaBuilder.struct().name(NAMESPACE + "." + getValueName())
+                    .field(Record.TIMESTAMP, Schema.INT64_SCHEMA)
+                    .field(Record.OPERATION, Schema.STRING_SCHEMA)
+                    .field(Record.SOURCE, sourceInfoStructMaker.schema())
+                    .field(Record.AFTER, rowSchema)
+                    .build();
+        }
+
+        public KeyValueSchema build() {
+            if (primaryKeyNames == null || primaryKeySchemas == null) {
+                if (tableMetadata == null) {
+                    throw new IllegalStateException("Unable to build, tableMetadata are null and either " +
+                            "primaryKeyNames and/or primaryKeyValues are not set.");
+                }
+            }
+            if (primaryKeyNames == null) {
+                primaryKeyNames = KeyValueSchema.getPrimaryKeyNames(tableMetadata);
+            }
+
+            if (primaryKeySchemas == null) {
+                primaryKeySchemas = KeyValueSchema.getPrimaryKeySchemas(tableMetadata);
+            }
+
+            if (rowSchema == null) {
+                if (tableMetadata != null) {
+                    rowSchema = RowData.rowSchema(tableMetadata);
+                }
+                else {
+                    throw new IllegalStateException("Unable to build, rowSchema is not set and table metadata are null");
+                }
+            }
+
+            if (keyspace == null) {
+                if (tableMetadata == null) {
+                    throw new IllegalStateException("Keyspace is not set and TableMetadata is not set either");
+                }
+                else {
+                    keyspace = tableMetadata.getKeyspace().toString();
+                }
+            }
+
+            if (table == null) {
+                if (tableMetadata == null) {
+                    throw new IllegalStateException("Table is not set and TableMetadata is not either");
+                }
+                else {
+                    table = tableMetadata.getName().toString();
+                }
+            }
+
+            return new KeyValueSchema(tableMetadata, getKeySchema(), getValueSchema());
+        }
+    }
+
+    public static List<String> getPrimaryKeyNames(TableMetadata tm) {
+        return tm.getPrimaryKey().stream().map(md -> md.getName().toString()).collect(Collectors.toList());
+    }
+
+    public static List<Schema> getPrimaryKeySchemas(TableMetadata tm) {
+        return tm.getPrimaryKey().stream()
+                .map(ColumnMetadata::getType)
+                .map(CassandraTypeConverter::convert)
+                .map(type -> CassandraTypeDeserializer.getSchemaBuilder(type).build())
+                .collect(Collectors.toList());
+    }
+
+    public static List<Schema> getPrimaryKeySchemas(List<DataType> dataTypes) {
+        return dataTypes.stream().map(CassandraTypeConverter::convert)
+                .map(type -> CassandraTypeDeserializer.getSchemaBuilder(type).build())
+                .collect(Collectors.toList());
     }
 
     public TableMetadata tableMetadata() {
@@ -44,41 +191,6 @@ public class KeyValueSchema {
 
     public Schema valueSchema() {
         return valueSchema;
-    }
-
-    private Schema getKeySchema(String kafkaTopicPrefix, TableMetadata tm) {
-        if (tm == null) {
-            return null;
-        }
-        SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(NAMESPACE + "." + getKeyName(kafkaTopicPrefix, tm));
-        for (ColumnMetadata cm : tm.getPrimaryKey()) {
-            AbstractType<?> convertedType = CassandraTypeConverter.convert(cm.getType());
-            Schema colSchema = CassandraTypeDeserializer.getSchemaBuilder(convertedType).build();
-            if (colSchema != null) {
-                schemaBuilder.field(cm.getName().toString(), colSchema);
-            }
-        }
-        return schemaBuilder.build();
-    }
-
-    private Schema getValueSchema(String kafkaTopicPrefix, TableMetadata tm, SourceInfoStructMaker sourceInfoStructMaker) {
-        if (tm == null) {
-            return null;
-        }
-        return SchemaBuilder.struct().name(NAMESPACE + "." + getValueName(kafkaTopicPrefix, tm))
-                .field(Record.TIMESTAMP, Schema.INT64_SCHEMA)
-                .field(Record.OPERATION, Schema.STRING_SCHEMA)
-                .field(Record.SOURCE, sourceInfoStructMaker.schema())
-                .field(Record.AFTER, RowData.rowSchema(tm))
-                .build();
-    }
-
-    private static String getKeyName(String kafkaTopicPrefix, TableMetadata tm) {
-        return kafkaTopicPrefix + "." + tm.getKeyspace() + "." + tm.getName() + ".Key";
-    }
-
-    private static String getValueName(String kafkaTopicPrefix, TableMetadata tm) {
-        return kafkaTopicPrefix + "." + tm.getKeyspace() + "." + tm.getName() + ".Envelope";
     }
 
     /**

--- a/core/src/main/java/io/debezium/connector/cassandra/QueueProcessor.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/QueueProcessor.java
@@ -29,7 +29,7 @@ public class QueueProcessor extends AbstractProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(QueueProcessor.class);
 
     private final ChangeEventQueue<Event> queue;
-    private final KafkaRecordEmitter kafkaRecordEmitter;
+    private final Emitter kafkaRecordEmitter;
     private final String commitLogRelocationDir;
     private final Set<String> erroneousCommitLogs;
 
@@ -56,7 +56,7 @@ public class QueueProcessor extends AbstractProcessor {
     }
 
     @VisibleForTesting
-    public QueueProcessor(CassandraConnectorContext context, int index, KafkaRecordEmitter emitter) {
+    public QueueProcessor(CassandraConnectorContext context, int index, Emitter emitter) {
         super(NAME_PREFIX + "[" + index + "]", Duration.ZERO);
         this.queue = context.getQueues().get(index);
         this.kafkaRecordEmitter = emitter;
@@ -100,7 +100,7 @@ public class QueueProcessor extends AbstractProcessor {
     }
 
     @Override
-    public void destroy() {
+    public void destroy() throws Exception {
         kafkaRecordEmitter.close();
     }
 

--- a/core/src/main/java/io/debezium/connector/cassandra/Record.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/Record.java
@@ -32,7 +32,8 @@ public abstract class Record implements Event {
     public enum Operation {
         INSERT("i"),
         UPDATE("u"),
-        DELETE("d");
+        DELETE("d"),
+        RANGE_TOMBSTONE("r");
 
         private String value;
 

--- a/core/src/main/java/io/debezium/connector/cassandra/RecordMaker.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/RecordMaker.java
@@ -47,6 +47,13 @@ public class RecordMaker {
                 data, keySchema, valueSchema, markOffset, consumer, Record.Operation.DELETE);
     }
 
+    public void rangeTombstone(String cluster, OffsetPosition offsetPosition, KeyspaceTable keyspaceTable, boolean snapshot,
+                               Instant tsMicro, RowData data, Schema keySchema, Schema valueSchema,
+                               boolean markOffset, BlockingConsumer<Record> consumer) {
+        createRecord(cluster, offsetPosition, keyspaceTable, snapshot, tsMicro,
+                data, keySchema, valueSchema, markOffset, consumer, Record.Operation.RANGE_TOMBSTONE);
+    }
+
     private void createRecord(String cluster, OffsetPosition offsetPosition, KeyspaceTable keyspaceTable, boolean snapshot,
                               Instant tsMicro, RowData data, Schema keySchema, Schema valueSchema,
                               boolean markOffset, BlockingConsumer<Record> consumer, Record.Operation operation) {
@@ -71,7 +78,7 @@ public class RecordMaker {
         catch (InterruptedException e) {
             e.printStackTrace();
             throw new CassandraConnectorTaskException(String.format(
-                    "Enqueuing has been interrupted while enqueuing Change Event %s", record.toString()), e);
+                    "Enqueuing has been interrupted while enqueuing Change Event %s", record), e);
         }
         if (operation == Record.Operation.DELETE && emitTombstoneOnDelete) {
             // generate kafka tombstone event
@@ -82,7 +89,7 @@ public class RecordMaker {
             catch (InterruptedException e) {
                 e.printStackTrace();
                 throw new CassandraConnectorTaskException(String.format(
-                        "Enqueuing has been interrupted while enqueuing Tombstone Event %s", record.toString()), e);
+                        "Enqueuing has been interrupted while enqueuing Tombstone Event %s", record), e);
             }
         }
     }

--- a/core/src/test/java/io/debezium/connector/cassandra/TestingKafkaRecordEmitter.java
+++ b/core/src/test/java/io/debezium/connector/cassandra/TestingKafkaRecordEmitter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.connect.storage.Converter;
+
+public class TestingKafkaRecordEmitter extends KafkaRecordEmitter {
+
+    public List<ProducerRecord<byte[], byte[]>> records = new ArrayList<>();
+
+    public TestingKafkaRecordEmitter(String kafkaTopicPrefix, String heartbeatPrefix, KafkaProducer kafkaProducer,
+                                     OffsetWriter offsetWriter, Duration offsetFlushIntervalMs, long maxOffsetFlushSize,
+                                     Converter keyConverter, Converter valueConverter, Set<String> erroneousCommitLogs,
+                                     CommitLogTransfer commitLogTransfer) {
+        super(kafkaTopicPrefix, heartbeatPrefix, kafkaProducer, offsetWriter, offsetFlushIntervalMs, maxOffsetFlushSize, keyConverter, valueConverter,
+                erroneousCommitLogs, commitLogTransfer);
+    }
+
+    @Override
+    public void emit(Record record) {
+        toProducerRecord(record);
+    }
+
+    @Override
+    protected ProducerRecord<byte[], byte[]> toProducerRecord(Record record) {
+        ProducerRecord<byte[], byte[]> producerRecord = super.toProducerRecord(record);
+        records.add(producerRecord);
+        return producerRecord;
+    }
+}


### PR DESCRIPTION
Hi @gunnarmorling , @bingqinzhou , @ahmedjami 

This patch adds support for partition key row deletion and range tombstones.

For range tombstones, it is introducing new struct called "bounds" with "start" and "end" fields.

This is the implementation for Cassandra 4 only for now. If we agree with the approach, I will try to introduce this to Cassandra 3 too.

There are added tests for each scenario for Cassandra 4 implementation.

Please tell me what you think about this.