### PR TITLE
DBZ-4910 Build Cassandra 3.x connector with Java 11

### DIFF
--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -60,9 +60,9 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Maven build core
         run: mvn clean install -f core/pom.xml -pl debezium-bom,debezium-core,debezium-embedded -am -DskipTests -DskipITs -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 17
       - name: Maven build cassandra
         run: mvn clean install -f cassandra/pom.xml -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,9 +34,9 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build Debezium Core
         run: mvn clean install -f core/pom.xml -pl debezium-bom,debezium-core -am -DskipTests -DskipITs -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 17
       - name: Build Debezium Connector Cassandra
         run: mvn clean install -f cassandra/pom.xml -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/cassandra-3/pom.xml
+++ b/cassandra-3/pom.xml
@@ -85,6 +85,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>
+                        --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens=java.base/java.io=ALL-UNNAMED
+                    </argLine>
                     <systemPropertyVariables>
                         <cassandra.version>${version.cassandra3}</cassandra.version>
                         <docker.dir>${project.basedir}/src/test/resources/docker</docker.dir>

--- a/cassandra-3/pom.xml
+++ b/cassandra-3/pom.xml
@@ -87,6 +87,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <cassandra.version>${version.cassandra3}</cassandra.version>
+                        <docker.dir>${project.basedir}/src/test/resources/docker</docker.dir>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/cassandra-3/src/test/resources/cassandra-unit-for-context.yaml
+++ b/cassandra-3/src/test/resources/cassandra-unit-for-context.yaml
@@ -70,7 +70,7 @@ max_hints_delivery_threads: 2
 
 # Directory where Cassandra should store hints.
 # If not set, the default directory is $CASSANDRA_HOME/data/hints.
-hints_directory: target/embeddedCassandra/data/hints
+hints_directory: target/data/cassandra/hints
 
 # How often hints should be flushed from the internal buffers to disk.
 # Will *not* trigger fsync.
@@ -188,12 +188,12 @@ partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 # the configured compaction strategy.
 # If not set, the default directory is $CASSANDRA_HOME/data/data.
 data_file_directories:
-  - target/data/embeddedCassandra/data/data
+  - target/data/cassandra/data
 
 # commit log.  when running on magnetic HDD, this should be a
 # separate spindle than the data directories.
 # If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
-commitlog_directory: target/data/embeddedCassandra/data/commitlog
+commitlog_directory: target/data/cassandra/commitlog
 
 # Enable / disable CDC functionality on a per-node basis. This modifies the logic used
 # for write path allocation rejection (standard: never reject. cdc: reject Mutation
@@ -205,7 +205,7 @@ cdc_enabled: true
 # separate spindle than the data directories. If not set, the default directory is
 # $CASSANDRA_HOME/data/cdc_raw.
 # cdc_raw_directory: /var/lib/cassandra/cdc_raw
-cdc_raw_directory: target/data/embeddedCassandra/data/commitlog
+cdc_raw_directory: target/data/cassandra/commitlog
 
 # Policy for data disk failures:
 #
@@ -366,7 +366,7 @@ counter_cache_save_period: 7200
 
 # saved caches
 # If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
-saved_caches_directory: target/embeddedCassandra/data/saved_caches
+saved_caches_directory: target/data/cassandra/saved_caches
 
 # commitlog_sync may be either "periodic" or "batch."
 #

--- a/cassandra-3/src/test/resources/docker/Dockerfile
+++ b/cassandra-3/src/test/resources/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM cassandra:3.11
+
+ENV CASSANDRA_YAML=/opt/cassandra/conf
+
+COPY cassandra.yaml $CASSANDRA_YAML
+
+RUN mkdir -p /var/lib/cassandra/data && \
+    chown -R cassandra:cassandra $CASSANDRA_YAML/cassandra.yaml /var/lib/cassandra/data && \
+    chmod 777 /var/lib/cassandra/data
+
+USER cassandra
+

--- a/cassandra-3/src/test/resources/docker/cassandra.yaml
+++ b/cassandra-3/src/test/resources/docker/cassandra.yaml
@@ -70,7 +70,7 @@ max_hints_delivery_threads: 2
 
 # Directory where Cassandra should store hints.
 # If not set, the default directory is $CASSANDRA_HOME/data/hints.
-hints_directory: data/hints
+hints_directory: /var/lib/cassandra/hints
 
 # How often hints should be flushed from the internal buffers to disk.
 # Will *not* trigger fsync.
@@ -188,12 +188,12 @@ partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 # the configured compaction strategy.
 # If not set, the default directory is $CASSANDRA_HOME/data/data.
 data_file_directories:
-  - data/data
+  - /var/lib/cassandra/data
 
 # commit log.  when running on magnetic HDD, this should be a
 # separate spindle than the data directories.
 # If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
-commitlog_directory: data/commitlog
+commitlog_directory: /var/lib/cassandra/commitlog
 
 # Enable / disable CDC functionality on a per-node basis. This modifies the logic used
 # for write path allocation rejection (standard: never reject. cdc: reject Mutation
@@ -204,8 +204,7 @@ cdc_enabled: true
 # segment contains mutations for a CDC-enabled table. This should be placed on a
 # separate spindle than the data directories. If not set, the default directory is
 # $CASSANDRA_HOME/data/cdc_raw.
-# cdc_raw_directory: /var/lib/cassandra/cdc_raw
-cdc_raw_directory: data/cdc_raw
+cdc_raw_directory: /var/lib/cassandra/cdc_raw_directory
 
 # Policy for data disk failures:
 #
@@ -366,7 +365,7 @@ counter_cache_save_period: 7200
 
 # saved caches
 # If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
-saved_caches_directory: data/saved_caches
+saved_caches_directory: /var/lib/cassandra/saved_caches
 
 # commitlog_sync may be either "periodic" or "batch."
 #
@@ -402,7 +401,7 @@ commitlog_sync_period_in_ms: 10000
 # NOTE: If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must
 # be set to at least twice the size of max_mutation_size_in_kb / 1024
 #
-commitlog_segment_size_in_mb: 32
+commitlog_segment_size_in_mb: 1
 
 # Compression to apply to the commit log. If omitted, the commit log
 # will be written uncompressed.  LZ4, Snappy, and Deflate compressors
@@ -547,12 +546,12 @@ memtable_allocation_type: heap_buffers
 #
 # The default value is the min of 4096 mb and 1/8th of the total space
 # of the drive where cdc_raw_directory resides.
-cdc_total_space_in_mb: 4096
+# cdc_total_space_in_mb: 4096
 
 # When we hit our cdc_raw limit and the CDCCompactor is either running behind
 # or experiencing backpressure, we check at the following interval to see if any
 # new space for cdc-tracked tables has been made available. Default to 250ms
-cdc_free_space_check_interval_ms: 250
+# cdc_free_space_check_interval_ms: 250
 
 # A fixed memory pool size in MB for for SSTable index summaries. If left
 # empty, this will default to 5% of the heap size. If the memory usage of
@@ -596,8 +595,8 @@ ssl_storage_port: 7001
 # address associated with the hostname (it might not be).
 #
 # Setting listen_address to 0.0.0.0 is always wrong.
-#
-listen_address: localhost
+
+listen_address: 127.0.0.1
 
 # Set listen_address OR listen_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -611,7 +610,7 @@ listen_address: localhost
 
 # Address to broadcast to other Cassandra nodes
 # Leaving this blank will set it to the same value as listen_address
-# broadcast_address: 1.2.3.4
+broadcast_address: 127.0.0.1
 
 # When using multiple physical network interfaces, set this
 # to true to listen on broadcast_address in addition to
@@ -674,7 +673,7 @@ start_rpc: false
 # set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: localhost
+rpc_address: 0.0.0.0
 
 # Set rpc_address OR rpc_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -693,7 +692,7 @@ rpc_port: 9160
 # be set to 0.0.0.0. If left blank, this will be set to the value of
 # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
 # be set.
-# broadcast_rpc_address: 1.2.3.4
+broadcast_rpc_address: 127.0.0.1
 
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true
@@ -1042,7 +1041,6 @@ server_encryption_options:
   # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
   # require_client_auth: false
   # require_endpoint_verification: false
-
 # enable or disable client/server encryption.
 client_encryption_options:
   enabled: false

--- a/cassandra-4/pom.xml
+++ b/cassandra-4/pom.xml
@@ -87,6 +87,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <cassandra.version>${version.cassandra4}</cassandra.version>
+                        <docker.dir>${project.basedir}/src/test/resources/docker</docker.dir>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/cassandra-4/pom.xml
+++ b/cassandra-4/pom.xml
@@ -85,6 +85,26 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- Taken from https://github.com/apache/cassandra/blob/trunk/conf/jvm11-clients.options and added java.base/java.io -->
+                    <argLine>
+                        --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                        --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                        --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED
+                        --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED
+                        --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED
+                        --add-exports java.sql/java.sql=ALL-UNNAMED
+                        --add-opens java.base/java.lang.module=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.math=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.module=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+                        --add-opens=java.base/java.io=ALL-UNNAMED
+                    </argLine>
                     <systemPropertyVariables>
                         <cassandra.version>${version.cassandra4}</cassandra.version>
                         <docker.dir>${project.basedir}/src/test/resources/docker</docker.dir>

--- a/cassandra-4/src/test/resources/docker/Dockerfile
+++ b/cassandra-4/src/test/resources/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM cassandra:4.0.3
+
+ENV CASSANDRA_YAML=/opt/cassandra/conf
+
+COPY cassandra.yaml $CASSANDRA_YAML
+
+RUN mkdir -p /var/lib/cassandra/data && \
+    chown -R cassandra:cassandra $CASSANDRA_YAML/cassandra.yaml /var/lib/cassandra/data && \
+    chmod 777 /var/lib/cassandra/data
+
+USER cassandra
+

--- a/cassandra-4/src/test/resources/docker/cassandra.yaml
+++ b/cassandra-4/src/test/resources/docker/cassandra.yaml
@@ -77,7 +77,7 @@ max_hints_delivery_threads: 2
 
 # Directory where Cassandra should store hints.
 # If not set, the default directory is $CASSANDRA_HOME/data/hints.
-hints_directory: data/hints
+hints_directory: /var/lib/cassandra/hints
 
 # How often hints should be flushed from the internal buffers to disk.
 # Will *not* trigger fsync.
@@ -205,12 +205,12 @@ partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 # the configured compaction strategy.
 # If not set, the default directory is $CASSANDRA_HOME/data/data.
 data_file_directories:
-  - data/data
+  - /var/lib/cassandra/data
 
 # commit log.  when running on magnetic HDD, this should be a
 # separate spindle than the data directories.
 # If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
-commitlog_directory: data/commitlog
+commitlog_directory: /var/lib/cassandra/commitlog
 
 # Enable / disable CDC functionality on a per-node basis. This modifies the logic used
 # for write path allocation rejection (standard: never reject. cdc: reject Mutation
@@ -222,7 +222,7 @@ cdc_enabled: true
 # separate spindle than the data directories. If not set, the default directory is
 # $CASSANDRA_HOME/data/cdc_raw.
 # cdc_raw_directory: /var/lib/cassandra/cdc_raw
-cdc_raw_directory: data/cdc_raw
+cdc_raw_directory: /var/lib/cassandra/cdc_raw_directory
 
 # Policy for data disk failures:
 #
@@ -374,7 +374,7 @@ counter_cache_save_period: 7200
 
 # saved caches
 # If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
-saved_caches_directory: data/saved_caches
+saved_caches_directory: /var/lib/cassandra/saved_caches
 
 # commitlog_sync may be either "periodic", "group", or "batch."
 #
@@ -653,7 +653,7 @@ ssl_storage_port: 7001
 #
 # Setting listen_address to 0.0.0.0 is always wrong.
 #
-listen_address: localhost
+listen_address: 127.0.0.1
 
 # Set listen_address OR listen_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -667,7 +667,7 @@ listen_address: localhost
 
 # Address to broadcast to other Cassandra nodes
 # Leaving this blank will set it to the same value as listen_address
-# broadcast_address: 1.2.3.4
+broadcast_address: 127.0.0.1
 
 # When using multiple physical network interfaces, set this
 # to true to listen on broadcast_address in addition to
@@ -737,7 +737,7 @@ native_transport_allow_older_protocols: true
 # set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: localhost
+rpc_address: 0.0.0.0
 
 # Set rpc_address OR rpc_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -753,7 +753,7 @@ rpc_address: localhost
 # be set to 0.0.0.0. If left blank, this will be set to the value of
 # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
 # be set.
-# broadcast_rpc_address: 1.2.3.4
+broadcast_rpc_address: 127.0.0.1
 
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,6 +56,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens=java.base/java.io=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,7 @@
     <properties>
         <!-- Debezium parent -->
         <version.debezium>${project.version}</version.debezium>
-
-        <!-- Enforce JDK 1.8 for building -->
-        <jdk.min.version>1.8</jdk.min.version>
-
+        
         <!-- Dependencies -->
         <version.dropwizard>4.0.1</version.dropwizard>
         <version.embedded.cassandra>4.0.6</version.embedded.cassandra>
@@ -346,15 +343,5 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <!-- Dependencies -->
         <version.dropwizard>4.0.1</version.dropwizard>
         <version.embedded.cassandra>4.0.6</version.embedded.cassandra>
+        <version.testcontainers>1.16.3</version.testcontainers>
     </properties>
 
     <repositories>
@@ -137,6 +138,13 @@
                         <artifactId>java-driver-core</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${version.testcontainers}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -281,6 +289,12 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Run Cassadra in container, build it with Java 11 and run the tests with Java 17.

https://issues.redhat.com/browse/DBZ-4910