### PR TITLE
DBZ-5043 Use topix.prefix instead of kafka.topic.prefix

### DIFF
--- a/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -90,9 +90,9 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
             .withDescription(
                     "Logical name for the Cassandra connector. This name should uniquely identify the connector from those that reside in other Cassandra nodes.");
 
-    public static final Field KAFKA_TOPIC_PREFIX = Field.create("kafka.topic.prefix")
+    public static final Field TOPIC_PREFIX = Field.create("topic.prefix")
             .withType(Type.STRING)
-            .withDescription("Logical name for the Cassandra cluster. This name should be identical across all Cassandra connectors in a Cassandra cluster");
+            .withDescription("Topic prefix for the Cassandra cluster. This name should be identical across all Cassandra connectors in a Cassandra cluster");
 
     public static final Field KEY_CONVERTER_CLASS_CONFIG = Field.create("key.converter")
             .withType(Type.STRING)
@@ -296,7 +296,7 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
     }
 
     public String kafkaTopicPrefix() {
-        return this.getConfig().getString(KAFKA_TOPIC_PREFIX);
+        return this.getConfig().getString(TOPIC_PREFIX);
     }
 
     public Properties getKafkaConfigs() {

--- a/core/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
+++ b/core/src/test/java/io/debezium/connector/cassandra/CassandraConnectorConfigTest.java
@@ -27,7 +27,7 @@ public class CassandraConnectorConfigTest {
         assertEquals(connectorName, config.connectorName());
 
         String kafkaTopicPrefix = "test_prefix";
-        config = buildTaskConfig(CassandraConnectorConfig.KAFKA_TOPIC_PREFIX.name(), kafkaTopicPrefix);
+        config = buildTaskConfig(CassandraConnectorConfig.TOPIC_PREFIX.name(), kafkaTopicPrefix);
         assertEquals(kafkaTopicPrefix, config.kafkaTopicPrefix());
 
         String snapshotConsistency = "ALL";

--- a/core/src/test/java/io/debezium/connector/cassandra/TestUtils.java
+++ b/core/src/test/java/io/debezium/connector/cassandra/TestUtils.java
@@ -44,7 +44,7 @@ public class TestUtils {
         Properties props = new Properties();
         props.put(CassandraConnectorConfig.CONNECTOR_NAME.name(), TEST_CONNECTOR_NAME);
         props.put(CassandraConnectorConfig.CASSANDRA_CONFIG.name(), Paths.get("src/test/resources/cassandra-unit-for-context.yaml").toAbsolutePath().toString());
-        props.put(CassandraConnectorConfig.KAFKA_TOPIC_PREFIX.name(), TEST_KAFKA_TOPIC_PREFIX);
+        props.put(CassandraConnectorConfig.TOPIC_PREFIX.name(), TEST_KAFKA_TOPIC_PREFIX);
         props.put(CassandraConnectorConfig.OFFSET_BACKING_STORE_DIR.name(), Files.createTempDirectory("offset").toString());
         props.put(CassandraConnectorConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, TEST_KAFKA_SERVERS);
         props.put(CassandraConnectorConfig.COMMIT_LOG_RELOCATION_DIR.name(), Files.createTempDirectory("cdc_raw_relocation").toString());
@@ -61,7 +61,7 @@ public class TestUtils {
             {
                 put(CassandraConnectorConfig.CONNECTOR_NAME.name(), TEST_CONNECTOR_NAME);
                 put(CassandraConnectorConfig.CASSANDRA_CONFIG.name(), Paths.get("src/test/resources/cassandra-unit-for-context.yaml").toAbsolutePath().toString());
-                put(CassandraConnectorConfig.KAFKA_TOPIC_PREFIX.name(), TEST_KAFKA_TOPIC_PREFIX);
+                put(CassandraConnectorConfig.TOPIC_PREFIX.name(), TEST_KAFKA_TOPIC_PREFIX);
                 put(CassandraConnectorConfig.OFFSET_BACKING_STORE_DIR.name(), Files.createTempDirectory("offset").toString());
                 put(CassandraConnectorConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, TEST_KAFKA_SERVERS);
                 put(CassandraConnectorConfig.COMMIT_LOG_RELOCATION_DIR.name(), Files.createTempDirectory("cdc_raw_relocation").toString());


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5043

Note: there's no need to update documentation in main Debezium repo as it was for some reason already done when switching to naming strategy in https://github.com/debezium/debezium/commit/daf329bc06