### PR TITLE
DBZ-5919: Refactor ComputePartition SMT to be more extensible on source info parsing

### DIFF
--- a/cassandra-3/pom.xml
+++ b/cassandra-3/pom.xml
@@ -47,6 +47,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cassandra-3/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/cassandra-3/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.cassandra.transforms.CassandraQualifiedTableNameResolver

--- a/cassandra-3/src/test/java/io/debezium/connector/cassandra/transforms/ComputePartitionTest.java
+++ b/cassandra-3/src/test/java/io/debezium/connector/cassandra/transforms/ComputePartitionTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra.transforms;
+
+import io.debezium.data.Envelope;
+import io.debezium.transforms.partitions.ComputePartition;
+import io.debezium.transforms.partitions.ComputePartitionException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.debezium.data.Envelope.Operation.CREATE;
+import static io.debezium.data.Envelope.Operation.DELETE;
+import static io.debezium.data.Envelope.Operation.TRUNCATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ComputePartitionTest {
+
+    public static final Schema VALUE_SCHEMA = SchemaBuilder.struct()
+            .name("server-1.inventory.products.Value")
+            .field("id", Schema.INT64_SCHEMA)
+            .field("price", Schema.FLOAT32_SCHEMA)
+            .field("product", Schema.STRING_SCHEMA)
+            .build();
+
+    private final ComputePartition<SourceRecord> computePartitionTransformation = new ComputePartition<>();
+
+    @Test
+    public void correctComputeKafkaPartitionBasedOnConfiguredFieldOnCreateAndUpdateEvents() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void correctComputeKafkaPartitionBasedOnConfiguredFieldOnDeleteEvents() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), DELETE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void partitionNotComputedOnTruncateEvent() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), TRUNCATE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isEqualTo(eventRecord.kafkaPartition());
+    }
+
+    @Test
+    public void rowWithSameConfiguredFieldValueWillHaveTheSamePartition() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        final SourceRecord eventRecord2 = buildSourceRecord("inventory", "products", productRow(2L, 2.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed2 = computePartitionTransformation.apply(eventRecord2);
+
+        assertThat(transformed1.kafkaPartition()).isZero();
+        assertThat(transformed2.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void rowWithDifferentConfiguredFieldValueWillHaveDifferentPartition() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        final SourceRecord eventRecord2 = buildSourceRecord("inventory", "products", productRow(3L, 0.95F, "BANANA"), CREATE);
+
+        SourceRecord transformed2 = computePartitionTransformation.apply(eventRecord2);
+
+        assertThat(transformed1.kafkaPartition()).isNotEqualTo(transformed2.kafkaPartition());
+    }
+
+    @Test
+    public void notConsistentConfigurationSizeWillThrowConnectionException() {
+
+        assertThatThrownBy(() -> configureTransformation("inventory.orders:purchaser,inventory.products:product", "purchaser:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings and partition.data-collections.field.mappings has different number of table defined");
+    }
+
+    @Test
+    public void notConsistentConfigurationWillThrowConnectionException() {
+
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:product", "prod:2,purchaser:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings and partition.data-collections.field.mappings has different tables defined");
+    }
+
+    @Test
+    public void negativeHashCodeValueWillBeCorrectlyManaged() {
+
+        configureTransformation("inventory.products:product", "inventory.products:3");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "orange"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        assertThat(transformed1.kafkaPartition()).isEqualTo(1);
+    }
+
+    @Test
+    public void zeroAsPartitionNumberWillThrowConnectionException() {
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:products",
+                        "inventory.products:0,inventory.orders:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings: partition number for 'inventory.products' must be positive");
+    }
+
+    @Test
+    public void negativeAsPartitionNumberWillThrowConnectionException() {
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:products",
+                        "inventory.products:-3,inventory.orders:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings: partition number for 'inventory.products' must be positive");
+    }
+
+    private SourceRecord buildSourceRecord(String keyspace, String tableName, Struct row, Envelope.Operation operation) {
+
+
+        SchemaBuilder sourceSchemaBuilder = SchemaBuilder.struct()
+                .name("source")
+                .field("connector", Schema.STRING_SCHEMA)
+                .field("db", Schema.STRING_SCHEMA)
+                .field("keyspace", Schema.STRING_SCHEMA)
+                .field("table", Schema.STRING_SCHEMA);
+
+        Schema sourceSchema = sourceSchemaBuilder.build();
+
+        Envelope createEnvelope = Envelope.defineSchema()
+                .withName("server-1.inventory.product.Envelope")
+                .withRecord(VALUE_SCHEMA)
+                .withSource(sourceSchema)
+                .build();
+
+        Struct source = new Struct(sourceSchema);
+        source.put("connector", "cassandra");
+        source.put("db", "cassandra");
+        source.put("table", tableName);
+        source.put("keyspace", keyspace);
+
+        Struct payload = createEnvelope.create(row, source, Instant.now());
+
+        switch (operation) {
+            case CREATE:
+            case UPDATE:
+            case READ:
+                payload = createEnvelope.create(row, source, Instant.now());
+                break;
+            case DELETE:
+                payload = createEnvelope.delete(row, source, Instant.now());
+                break;
+            case TRUNCATE:
+                payload = createEnvelope.truncate(source, Instant.now());
+                break;
+        }
+
+        return new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "prefix.inventory.products",
+                createEnvelope.schema(), payload);
+    }
+
+    private void configureTransformation(String tableFieldMapping, String tablePartitionNumMapping) {
+        computePartitionTransformation.configure(Map.of(
+                "partition.data-collections.field.mappings", tableFieldMapping,
+                "partition.data-collections.partition.num.mappings", tablePartitionNumMapping));
+    }
+
+    private Struct productRow(long id, float price, String name) {
+        return new Struct(VALUE_SCHEMA)
+                .put("id", id)
+                .put("price", price)
+                .put("product", name);
+    }
+}

--- a/cassandra-3/src/test/java/io/debezium/connector/cassandra/transforms/ComputePartitionTest.java
+++ b/cassandra-3/src/test/java/io/debezium/connector/cassandra/transforms/ComputePartitionTest.java
@@ -5,24 +5,25 @@
  */
 package io.debezium.connector.cassandra.transforms;
 
-import io.debezium.data.Envelope;
-import io.debezium.transforms.partitions.ComputePartition;
-import io.debezium.transforms.partitions.ComputePartitionException;
+import static io.debezium.data.Envelope.Operation.CREATE;
+import static io.debezium.data.Envelope.Operation.DELETE;
+import static io.debezium.data.Envelope.Operation.TRUNCATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
 
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-
-import static io.debezium.data.Envelope.Operation.CREATE;
-import static io.debezium.data.Envelope.Operation.DELETE;
-import static io.debezium.data.Envelope.Operation.TRUNCATE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import io.debezium.data.Envelope;
+import io.debezium.transforms.partitions.ComputePartition;
+import io.debezium.transforms.partitions.ComputePartitionException;
 
 public class ComputePartitionTest {
 
@@ -156,7 +157,6 @@ public class ComputePartitionTest {
     }
 
     private SourceRecord buildSourceRecord(String keyspace, String tableName, Struct row, Envelope.Operation operation) {
-
 
         SchemaBuilder sourceSchemaBuilder = SchemaBuilder.struct()
                 .name("source")

--- a/cassandra-3/src/test/resources/META-INF.services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/cassandra-3/src/test/resources/META-INF.services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.cassandra.transforms.CassandraQualifiedTableNameResolver

--- a/cassandra-4/pom.xml
+++ b/cassandra-4/pom.xml
@@ -47,6 +47,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cassandra-4/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/cassandra-4/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.cassandra.transforms.CassandraQualifiedTableNameResolver

--- a/cassandra-4/src/test/java/io/debezium/connector/cassandra/transforms/ComputePartitionTest.java
+++ b/cassandra-4/src/test/java/io/debezium/connector/cassandra/transforms/ComputePartitionTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra.transforms;
+
+import static io.debezium.data.Envelope.Operation.CREATE;
+import static io.debezium.data.Envelope.Operation.DELETE;
+import static io.debezium.data.Envelope.Operation.TRUNCATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import io.debezium.data.Envelope;
+import io.debezium.transforms.partitions.ComputePartition;
+import io.debezium.transforms.partitions.ComputePartitionException;
+
+public class ComputePartitionTest {
+
+    public static final Schema VALUE_SCHEMA = SchemaBuilder.struct()
+            .name("server-1.inventory.products.Value")
+            .field("id", Schema.INT64_SCHEMA)
+            .field("price", Schema.FLOAT32_SCHEMA)
+            .field("product", Schema.STRING_SCHEMA)
+            .build();
+
+    private final ComputePartition<SourceRecord> computePartitionTransformation = new ComputePartition<>();
+
+    @Test
+    public void correctComputeKafkaPartitionBasedOnConfiguredFieldOnCreateAndUpdateEvents() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void correctComputeKafkaPartitionBasedOnConfiguredFieldOnDeleteEvents() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), DELETE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void partitionNotComputedOnTruncateEvent() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), TRUNCATE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isEqualTo(eventRecord.kafkaPartition());
+    }
+
+    @Test
+    public void rowWithSameConfiguredFieldValueWillHaveTheSamePartition() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        final SourceRecord eventRecord2 = buildSourceRecord("inventory", "products", productRow(2L, 2.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed2 = computePartitionTransformation.apply(eventRecord2);
+
+        assertThat(transformed1.kafkaPartition()).isZero();
+        assertThat(transformed2.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void rowWithDifferentConfiguredFieldValueWillHaveDifferentPartition() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        final SourceRecord eventRecord2 = buildSourceRecord("inventory", "products", productRow(3L, 0.95F, "BANANA"), CREATE);
+
+        SourceRecord transformed2 = computePartitionTransformation.apply(eventRecord2);
+
+        assertThat(transformed1.kafkaPartition()).isNotEqualTo(transformed2.kafkaPartition());
+    }
+
+    @Test
+    public void notConsistentConfigurationSizeWillThrowConnectionException() {
+
+        assertThatThrownBy(() -> configureTransformation("inventory.orders:purchaser,inventory.products:product", "purchaser:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings and partition.data-collections.field.mappings has different number of table defined");
+    }
+
+    @Test
+    public void notConsistentConfigurationWillThrowConnectionException() {
+
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:product", "prod:2,purchaser:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings and partition.data-collections.field.mappings has different tables defined");
+    }
+
+    @Test
+    public void negativeHashCodeValueWillBeCorrectlyManaged() {
+
+        configureTransformation("inventory.products:product", "inventory.products:3");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "orange"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        assertThat(transformed1.kafkaPartition()).isEqualTo(1);
+    }
+
+    @Test
+    public void zeroAsPartitionNumberWillThrowConnectionException() {
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:products",
+                        "inventory.products:0,inventory.orders:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings: partition number for 'inventory.products' must be positive");
+    }
+
+    @Test
+    public void negativeAsPartitionNumberWillThrowConnectionException() {
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:products",
+                        "inventory.products:-3,inventory.orders:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings: partition number for 'inventory.products' must be positive");
+    }
+
+    private SourceRecord buildSourceRecord(String keyspace, String tableName, Struct row, Envelope.Operation operation) {
+
+        SchemaBuilder sourceSchemaBuilder = SchemaBuilder.struct()
+                .name("source")
+                .field("connector", Schema.STRING_SCHEMA)
+                .field("db", Schema.STRING_SCHEMA)
+                .field("keyspace", Schema.STRING_SCHEMA)
+                .field("table", Schema.STRING_SCHEMA);
+
+        Schema sourceSchema = sourceSchemaBuilder.build();
+
+        Envelope createEnvelope = Envelope.defineSchema()
+                .withName("server-1.inventory.product.Envelope")
+                .withRecord(VALUE_SCHEMA)
+                .withSource(sourceSchema)
+                .build();
+
+        Struct source = new Struct(sourceSchema);
+        source.put("connector", "cassandra");
+        source.put("db", "cassandra");
+        source.put("table", tableName);
+        source.put("keyspace", keyspace);
+
+        Struct payload = createEnvelope.create(row, source, Instant.now());
+
+        switch (operation) {
+            case CREATE:
+            case UPDATE:
+            case READ:
+                payload = createEnvelope.create(row, source, Instant.now());
+                break;
+            case DELETE:
+                payload = createEnvelope.delete(row, source, Instant.now());
+                break;
+            case TRUNCATE:
+                payload = createEnvelope.truncate(source, Instant.now());
+                break;
+        }
+
+        return new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "prefix.inventory.products",
+                createEnvelope.schema(), payload);
+    }
+
+    private void configureTransformation(String tableFieldMapping, String tablePartitionNumMapping) {
+        computePartitionTransformation.configure(Map.of(
+                "partition.data-collections.field.mappings", tableFieldMapping,
+                "partition.data-collections.partition.num.mappings", tablePartitionNumMapping));
+    }
+
+    private Struct productRow(long id, float price, String name) {
+        return new Struct(VALUE_SCHEMA)
+                .put("id", id)
+                .put("price", price)
+                .put("product", name);
+    }
+}

--- a/cassandra-4/src/test/resources/META-INF.services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/cassandra-4/src/test/resources/META-INF.services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.cassandra.transforms.CassandraQualifiedTableNameResolver

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,6 +19,11 @@
             <artifactId>commons-math3</artifactId>
             <version>3.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/io/debezium/connector/cassandra/converters/CassandraRecordParser.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/converters/CassandraRecordParser.java
@@ -5,15 +5,16 @@
  */
 package io.debezium.connector.cassandra.converters;
 
-import io.debezium.connector.cassandra.SourceInfo;
-import io.debezium.converters.spi.RecordParser;
-import io.debezium.data.Envelope;
-import io.debezium.util.Collect;
+import java.util.Set;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
-import java.util.Set;
+import io.debezium.connector.cassandra.SourceInfo;
+import io.debezium.converters.spi.RecordParser;
+import io.debezium.data.Envelope;
+import io.debezium.util.Collect;
 
 /**
  * Parser for records produced by the Cassandra connector.

--- a/core/src/main/java/io/debezium/connector/cassandra/converters/CassandraRecordParser.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/converters/CassandraRecordParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra.converters;
+
+import io.debezium.connector.cassandra.SourceInfo;
+import io.debezium.converters.spi.RecordParser;
+import io.debezium.data.Envelope;
+import io.debezium.util.Collect;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+
+import java.util.Set;
+
+/**
+ * Parser for records produced by the Cassandra connector.
+ *
+ * @author Mario Fiore Vitale
+ */
+public class CassandraRecordParser extends RecordParser {
+
+    private static final Set<String> CASSANDRA_SOURCE_FIELD = Collect.unmodifiableSet(
+            SourceInfo.KEYSPACE_NAME_KEY,
+            SourceInfo.TABLE_NAME_KEY);
+
+    public CassandraRecordParser(Schema schema, Struct record) {
+        super(schema, record, Envelope.FieldName.BEFORE, Envelope.FieldName.AFTER);
+    }
+
+    @Override
+    public Object getMetadata(String name) {
+        if (SOURCE_FIELDS.contains(name)) {
+            return source().get(name);
+        }
+        if (CASSANDRA_SOURCE_FIELD.contains(name)) {
+            return source().get(name);
+        }
+
+        throw new DataException("No such field \"" + name + "\" in the \"source\" field of events from Cassandra connector");
+    }
+}

--- a/core/src/main/java/io/debezium/connector/cassandra/transforms/CassandraAbstractRecordParserProvider.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/transforms/CassandraAbstractRecordParserProvider.java
@@ -5,11 +5,12 @@
  */
 package io.debezium.connector.cassandra.transforms;
 
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
 import io.debezium.connector.cassandra.converters.CassandraRecordParser;
 import io.debezium.converters.spi.RecordParser;
 import io.debezium.transforms.spi.RecordParserProvider;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 
 public abstract class CassandraAbstractRecordParserProvider implements RecordParserProvider {
 

--- a/core/src/main/java/io/debezium/connector/cassandra/transforms/CassandraAbstractRecordParserProvider.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/transforms/CassandraAbstractRecordParserProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra.transforms;
+
+import io.debezium.connector.cassandra.converters.CassandraRecordParser;
+import io.debezium.converters.spi.RecordParser;
+import io.debezium.transforms.spi.RecordParserProvider;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+public abstract class CassandraAbstractRecordParserProvider implements RecordParserProvider {
+
+    @Override
+    public String getName() {
+        return "cassandra";
+    }
+
+    @Override
+    public RecordParser createParser(Schema schema, Struct record) {
+        return new CassandraRecordParser(schema, record);
+    }
+}

--- a/core/src/main/java/io/debezium/connector/cassandra/transforms/CassandraQualifiedTableNameResolver.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/transforms/CassandraQualifiedTableNameResolver.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra.transforms;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.cassandra.SourceInfo;
+import io.debezium.converters.spi.RecordParser;
+import io.debezium.transforms.spi.QualifiedTableNameResolver;
+
+public class CassandraQualifiedTableNameResolver extends CassandraAbstractRecordParserProvider implements QualifiedTableNameResolver {
+    public static final String FULLY_QUALIFIED_NAME_FORMAT = "%s.%s";
+
+    @Override
+    public String resolve(RecordParser recordParser) {
+        return String.format(FULLY_QUALIFIED_NAME_FORMAT,
+                recordParser.getMetadata(SourceInfo.KEYSPACE_NAME_KEY),
+                recordParser.getMetadata(AbstractSourceInfo.TABLE_NAME_KEY));
+    }
+}

--- a/dse/pom.xml
+++ b/dse/pom.xml
@@ -105,6 +105,11 @@
             <version>1.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dse/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/dse/src/main/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.cassandra.transforms.CassandraQualifiedTableNameResolver

--- a/dse/src/test/java/io/debezium/connector/dse/transforms/ComputePartitionTest.java
+++ b/dse/src/test/java/io/debezium/connector/dse/transforms/ComputePartitionTest.java
@@ -5,24 +5,25 @@
  */
 package io.debezium.connector.dse.transforms;
 
-import io.debezium.data.Envelope;
-import io.debezium.transforms.partitions.ComputePartition;
-import io.debezium.transforms.partitions.ComputePartitionException;
+import static io.debezium.data.Envelope.Operation.CREATE;
+import static io.debezium.data.Envelope.Operation.DELETE;
+import static io.debezium.data.Envelope.Operation.TRUNCATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
 
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-
-import static io.debezium.data.Envelope.Operation.CREATE;
-import static io.debezium.data.Envelope.Operation.DELETE;
-import static io.debezium.data.Envelope.Operation.TRUNCATE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import io.debezium.data.Envelope;
+import io.debezium.transforms.partitions.ComputePartition;
+import io.debezium.transforms.partitions.ComputePartitionException;
 
 public class ComputePartitionTest {
 

--- a/dse/src/test/java/io/debezium/connector/dse/transforms/ComputePartitionTest.java
+++ b/dse/src/test/java/io/debezium/connector/dse/transforms/ComputePartitionTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.dse.transforms;
+
+import io.debezium.data.Envelope;
+import io.debezium.transforms.partitions.ComputePartition;
+import io.debezium.transforms.partitions.ComputePartitionException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.debezium.data.Envelope.Operation.CREATE;
+import static io.debezium.data.Envelope.Operation.DELETE;
+import static io.debezium.data.Envelope.Operation.TRUNCATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ComputePartitionTest {
+
+    public static final Schema VALUE_SCHEMA = SchemaBuilder.struct()
+            .name("server-1.inventory.products.Value")
+            .field("id", Schema.INT64_SCHEMA)
+            .field("price", Schema.FLOAT32_SCHEMA)
+            .field("product", Schema.STRING_SCHEMA)
+            .build();
+
+    private final ComputePartition<SourceRecord> computePartitionTransformation = new ComputePartition<>();
+
+    @Test
+    public void correctComputeKafkaPartitionBasedOnConfiguredFieldOnCreateAndUpdateEvents() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void correctComputeKafkaPartitionBasedOnConfiguredFieldOnDeleteEvents() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), DELETE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void partitionNotComputedOnTruncateEvent() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), TRUNCATE);
+
+        SourceRecord transformed = computePartitionTransformation.apply(eventRecord);
+
+        assertThat(transformed.kafkaPartition()).isEqualTo(eventRecord.kafkaPartition());
+    }
+
+    @Test
+    public void rowWithSameConfiguredFieldValueWillHaveTheSamePartition() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        final SourceRecord eventRecord2 = buildSourceRecord("inventory", "products", productRow(2L, 2.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed2 = computePartitionTransformation.apply(eventRecord2);
+
+        assertThat(transformed1.kafkaPartition()).isZero();
+        assertThat(transformed2.kafkaPartition()).isZero();
+    }
+
+    @Test
+    public void rowWithDifferentConfiguredFieldValueWillHaveDifferentPartition() {
+
+        configureTransformation("inventory.products:product", "inventory.products:2");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "APPLE"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        final SourceRecord eventRecord2 = buildSourceRecord("inventory", "products", productRow(3L, 0.95F, "BANANA"), CREATE);
+
+        SourceRecord transformed2 = computePartitionTransformation.apply(eventRecord2);
+
+        assertThat(transformed1.kafkaPartition()).isNotEqualTo(transformed2.kafkaPartition());
+    }
+
+    @Test
+    public void notConsistentConfigurationSizeWillThrowConnectionException() {
+
+        assertThatThrownBy(() -> configureTransformation("inventory.orders:purchaser,inventory.products:product", "purchaser:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings and partition.data-collections.field.mappings has different number of table defined");
+    }
+
+    @Test
+    public void notConsistentConfigurationWillThrowConnectionException() {
+
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:product", "prod:2,purchaser:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings and partition.data-collections.field.mappings has different tables defined");
+    }
+
+    @Test
+    public void negativeHashCodeValueWillBeCorrectlyManaged() {
+
+        configureTransformation("inventory.products:product", "inventory.products:3");
+
+        final SourceRecord eventRecord1 = buildSourceRecord("inventory", "products", productRow(1L, 1.0F, "orange"), CREATE);
+
+        SourceRecord transformed1 = computePartitionTransformation.apply(eventRecord1);
+
+        assertThat(transformed1.kafkaPartition()).isEqualTo(1);
+    }
+
+    @Test
+    public void zeroAsPartitionNumberWillThrowConnectionException() {
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:products",
+                        "inventory.products:0,inventory.orders:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings: partition number for 'inventory.products' must be positive");
+    }
+
+    @Test
+    public void negativeAsPartitionNumberWillThrowConnectionException() {
+        assertThatThrownBy(
+                () -> configureTransformation("inventory.orders:purchaser,inventory.products:products",
+                        "inventory.products:-3,inventory.orders:2"))
+                .isInstanceOf(ComputePartitionException.class)
+                .hasMessageContaining(
+                        "Unable to validate config. partition.data-collections.partition.num.mappings: partition number for 'inventory.products' must be positive");
+    }
+
+    private SourceRecord buildSourceRecord(String keyspace, String tableName, Struct row, Envelope.Operation operation) {
+
+        SchemaBuilder sourceSchemaBuilder = SchemaBuilder.struct()
+                .name("source")
+                .field("connector", Schema.STRING_SCHEMA)
+                .field("db", Schema.STRING_SCHEMA)
+                .field("keyspace", Schema.STRING_SCHEMA)
+                .field("table", Schema.STRING_SCHEMA);
+
+        Schema sourceSchema = sourceSchemaBuilder.build();
+
+        Envelope createEnvelope = Envelope.defineSchema()
+                .withName("server-1.inventory.product.Envelope")
+                .withRecord(VALUE_SCHEMA)
+                .withSource(sourceSchema)
+                .build();
+
+        Struct source = new Struct(sourceSchema);
+        source.put("connector", "cassandra");
+        source.put("db", "cassandra");
+        source.put("table", tableName);
+        source.put("keyspace", keyspace);
+
+        Struct payload = createEnvelope.create(row, source, Instant.now());
+
+        switch (operation) {
+            case CREATE:
+            case UPDATE:
+            case READ:
+                payload = createEnvelope.create(row, source, Instant.now());
+                break;
+            case DELETE:
+                payload = createEnvelope.delete(row, source, Instant.now());
+                break;
+            case TRUNCATE:
+                payload = createEnvelope.truncate(source, Instant.now());
+                break;
+        }
+
+        return new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "prefix.inventory.products",
+                createEnvelope.schema(), payload);
+    }
+
+    private void configureTransformation(String tableFieldMapping, String tablePartitionNumMapping) {
+        computePartitionTransformation.configure(Map.of(
+                "partition.data-collections.field.mappings", tableFieldMapping,
+                "partition.data-collections.partition.num.mappings", tablePartitionNumMapping));
+    }
+
+    private Struct productRow(long id, float price, String name) {
+        return new Struct(VALUE_SCHEMA)
+                .put("id", id)
+                .put("price", price)
+                .put("product", name);
+    }
+}

--- a/dse/src/test/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
+++ b/dse/src/test/resources/META-INF/services/io.debezium.transforms.spi.QualifiedTableNameResolver
@@ -1,0 +1,1 @@
+io.debezium.connector.cassandra.transforms.CassandraQualifiedTableNameResolver


### PR DESCRIPTION
Implement QualifiedTableNameResolver for ComputePartition SMT

Depends on [#DBZ-5919](https://github.com/debezium/debezium/pull/4361)