### PR TITLE
DBZ-7722 Performance improve in KafkaRecordEmitter class

### DIFF
--- a/cassandra-3/src/test/java/io/debezium/connector/cassandra/EmbeddedCassandra3ConnectorTestBase.java
+++ b/cassandra-3/src/test/java/io/debezium/connector/cassandra/EmbeddedCassandra3ConnectorTestBase.java
@@ -23,6 +23,6 @@ public class EmbeddedCassandra3ConnectorTestBase extends CassandraConnectorTestB
         return new CassandraConnectorContext(config,
                 new Cassandra3SchemaLoader(),
                 new Cassandra3SchemaChangeListenerProvider(),
-                new FileOffsetWriter(config.offsetBackingStoreDir()));
+                new FileOffsetWriter(config));
     }
 }

--- a/cassandra-4/src/test/java/io/debezium/connector/cassandra/EmbeddedCassandra4ConnectorTestBase.java
+++ b/cassandra-4/src/test/java/io/debezium/connector/cassandra/EmbeddedCassandra4ConnectorTestBase.java
@@ -23,6 +23,6 @@ public abstract class EmbeddedCassandra4ConnectorTestBase extends CassandraConne
         return new CassandraConnectorContext(config,
                 new Cassandra4SchemaLoader(),
                 new Cassandra4SchemaChangeListenerProvider(),
-                new FileOffsetWriter(config.offsetBackingStoreDir()));
+                new FileOffsetWriter(config));
     }
 }

--- a/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -534,7 +534,7 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
      * See {@link EventOrderGuaranteeMode for details}.
      */
     public static final Field EVENT_ORDER_GUARANTEE_MODE = Field.create("event.order.guarantee.mode")
-            .withDisplayName("VarInt Handling")
+            .withDisplayName("Event order guarantee")
             .withEnum(EventOrderGuaranteeMode.class, EventOrderGuaranteeMode.COMMITLOG_FILE)
             .withImportance(Importance.MEDIUM)
             .withDescription("Specifies how grantee order of change events.");

--- a/core/src/main/java/io/debezium/connector/cassandra/ComponentFactoryDebezium.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/ComponentFactoryDebezium.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.connector.cassandra;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.DataChangeEvent;
@@ -36,8 +39,9 @@ public class ComponentFactoryDebezium implements ComponentFactory {
         return new OffsetWriter() {
 
             @Override
-            public void markOffset(String sourceTable, String sourceOffset, boolean isSnapshot) {
+            public Future<?> markOffset(String sourceTable, String sourceOffset, boolean isSnapshot) {
                 offset.putOffset(sourceTable, isSnapshot, sourceOffset);
+                return CompletableFuture.completedFuture(new Object());
             }
 
             @Override
@@ -50,8 +54,8 @@ public class ComponentFactoryDebezium implements ComponentFactory {
             }
 
             @Override
-            public void flush() {
-
+            public Future<?> flush() {
+                return CompletableFuture.completedFuture(new Object());
             }
 
             @Override

--- a/core/src/main/java/io/debezium/connector/cassandra/ComponentFactoryStandalone.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/ComponentFactoryStandalone.java
@@ -16,7 +16,7 @@ public class ComponentFactoryStandalone implements ComponentFactory {
     @Override
     public OffsetWriter offsetWriter(CassandraConnectorConfig config) {
         try {
-            return new FileOffsetWriter(config.offsetBackingStoreDir(), config.offsetFlushIntervalMs(), config.maxOffsetFlushSize());
+            return new FileOffsetWriter(config);
         }
         catch (IOException e) {
             throw new CassandraConnectorConfigException(String.format("cannot create file offset writer into %s", config.offsetBackingStoreDir()), e);

--- a/core/src/main/java/io/debezium/connector/cassandra/ComponentFactoryStandalone.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/ComponentFactoryStandalone.java
@@ -16,7 +16,7 @@ public class ComponentFactoryStandalone implements ComponentFactory {
     @Override
     public OffsetWriter offsetWriter(CassandraConnectorConfig config) {
         try {
-            return new FileOffsetWriter(config.offsetBackingStoreDir());
+            return new FileOffsetWriter(config.offsetBackingStoreDir(), config.offsetFlushIntervalMs(), config.maxOffsetFlushSize());
         }
         catch (IOException e) {
             throw new CassandraConnectorConfigException(String.format("cannot create file offset writer into %s", config.offsetBackingStoreDir()), e);
@@ -30,8 +30,6 @@ public class ComponentFactoryStandalone implements ComponentFactory {
                 config,
                 new KafkaProducer<>(config.getKafkaConfigs()),
                 context.getOffsetWriter(),
-                config.offsetFlushIntervalMs(),
-                config.maxOffsetFlushSize(),
                 config.getKeyConverter(),
                 config.getValueConverter(),
                 context.getErroneousCommitLogs(),

--- a/core/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
@@ -23,6 +23,7 @@ import io.debezium.spi.topic.TopicNamingStrategy;
  */
 public class KafkaRecordEmitter implements Emitter {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaRecordEmitter.class);
+    private static final int RECORD_LOG_COUNT = 10_000;
 
     private final KafkaProducer<byte[], byte[]> producer;
     private final TopicNamingStrategy<KeyspaceTable> topicNamingStrategy;
@@ -75,7 +76,7 @@ public class KafkaRecordEmitter implements Emitter {
             return;
         }
         long emitted = emitCount.incrementAndGet();
-        if (emitted % 10_000 == 0) {
+        if (emitted % RECORD_LOG_COUNT == 0) {
             LOGGER.debug("Emitted {} records to Kafka Broker", emitted);
             emitCount.addAndGet(-emitted);
         }

--- a/core/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
@@ -5,16 +5,11 @@
  */
 package io.debezium.connector.cassandra;
 
-import java.time.Duration;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.storage.Converter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,25 +27,19 @@ public class KafkaRecordEmitter implements Emitter {
     private final KafkaProducer<byte[], byte[]> producer;
     private final TopicNamingStrategy<KeyspaceTable> topicNamingStrategy;
     private final OffsetWriter offsetWriter;
-    private final OffsetFlushPolicy offsetFlushPolicy;
     private final Set<String> erroneousCommitLogs;
     private final CommitLogTransfer commitLogTransfer;
-    private final Map<Record, Future<RecordMetadata>> futures = new LinkedHashMap<>();
-    private final Object lock = new Object();
     private final Converter keyConverter;
     private final Converter valueConverter;
-    private long timeOfLastFlush;
-    private long emitCount = 0;
+    private final AtomicLong emitCount = new AtomicLong();
 
     @SuppressWarnings("unchecked")
     public KafkaRecordEmitter(CassandraConnectorConfig connectorConfig, KafkaProducer<byte[], byte[]> kafkaProducer,
-                              OffsetWriter offsetWriter, Duration offsetFlushIntervalMs, long maxOffsetFlushSize,
-                              Converter keyConverter, Converter valueConverter, Set<String> erroneousCommitLogs,
-                              CommitLogTransfer commitLogTransfer) {
+                              OffsetWriter offsetWriter, Converter keyConverter, Converter valueConverter,
+                              Set<String> erroneousCommitLogs, CommitLogTransfer commitLogTransfer) {
         this.producer = kafkaProducer;
         this.topicNamingStrategy = connectorConfig.getTopicNamingStrategy(CommonConnectorConfig.TOPIC_NAMING_STRATEGY);
         this.offsetWriter = offsetWriter;
-        this.offsetFlushPolicy = offsetFlushIntervalMs.isZero() ? OffsetFlushPolicy.always() : OffsetFlushPolicy.periodic(offsetFlushIntervalMs, maxOffsetFlushSize);
         this.erroneousCommitLogs = erroneousCommitLogs;
         this.commitLogTransfer = commitLogTransfer;
         this.keyConverter = keyConverter;
@@ -60,13 +49,9 @@ public class KafkaRecordEmitter implements Emitter {
     @Override
     public void emit(Record record) {
         try {
-            synchronized (lock) {
-                ProducerRecord<byte[], byte[]> producerRecord = toProducerRecord(record);
-                Future<RecordMetadata> future = producer.send(producerRecord);
-                LOGGER.trace("Sent to topic {}: {}", producerRecord.topic(), record);
-                futures.put(record, future);
-                maybeFlushAndMarkOffset();
-            }
+            ProducerRecord<byte[], byte[]> producerRecord = toProducerRecord(record);
+            producer.send(producerRecord, (metadata, exception) -> callback(record, exception));
+            LOGGER.trace("Sent to topic {}: {}", producerRecord.topic(), record);
         }
         catch (Exception e) {
             if (record.getSource().snapshot || commitLogTransfer.getClass().getName().equals(CassandraConnectorConfig.DEFAULT_COMMIT_LOG_TRANSFER_CLASS)) {
@@ -84,46 +69,30 @@ public class KafkaRecordEmitter implements Emitter {
         return new ProducerRecord<>(topic, serializedKey, serializedValue);
     }
 
-    private void maybeFlushAndMarkOffset() {
-        long now = System.currentTimeMillis();
-        long timeSinceLastFlush = now - timeOfLastFlush;
-        if (offsetFlushPolicy.shouldFlush(Duration.ofMillis(timeSinceLastFlush), futures.size())) {
-            flushAndMarkOffset();
-            timeOfLastFlush = now;
+    private void callback(Record record, Exception exception) {
+        if (exception != null) {
+            LOGGER.error("Failed to emit record {}", record, exception);
+            return;
+        }
+        long emitted = emitCount.incrementAndGet();
+        if (emitted % 10_000 == 0) {
+            LOGGER.debug("Emitted {} records to Kafka Broker", emitted);
+            emitCount.addAndGet(-emitted);
+        }
+        if (hasOffset(record)) {
+            markOffset(record);
         }
     }
 
-    private void flushAndMarkOffset() {
-        futures.entrySet().stream().filter(this::flush).filter(this::hasOffset).forEach(this::markOffset);
-        offsetWriter.flush();
-        futures.clear();
-    }
-
-    private boolean flush(Map.Entry<Record, Future<RecordMetadata>> recordEntry) {
-        try {
-            recordEntry.getValue().get(); // wait
-            if (++emitCount % 10_000 == 0) {
-                LOGGER.debug("Emitted {} records to Kafka Broker", emitCount);
-                emitCount = 0;
-            }
-            return true;
-        }
-        catch (ExecutionException | InterruptedException e) {
-            LOGGER.error("Failed to emit record {}", recordEntry.getKey(), e);
-            return false;
-        }
-    }
-
-    private boolean hasOffset(Map.Entry<Record, Future<RecordMetadata>> recordEntry) {
-        Record record = recordEntry.getKey();
+    private boolean hasOffset(Record record) {
         if (record.getSource().snapshot || commitLogTransfer.getClass().getName().equals(CassandraConnectorConfig.DEFAULT_COMMIT_LOG_TRANSFER_CLASS)) {
             return record.shouldMarkOffset();
         }
         return record.shouldMarkOffset() && !erroneousCommitLogs.contains(record.getSource().offsetPosition.fileName);
     }
 
-    private void markOffset(Map.Entry<Record, Future<RecordMetadata>> recordEntry) {
-        SourceInfo source = recordEntry.getKey().getSource();
+    private void markOffset(Record record) {
+        SourceInfo source = record.getSource();
         String sourceTable = source.keyspaceTable.name();
         String sourceOffset = source.offsetPosition.serialize();
         boolean isSnapshot = source.snapshot;

--- a/core/src/main/java/io/debezium/connector/cassandra/OffsetFlushPolicy.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/OffsetFlushPolicy.java
@@ -23,6 +23,10 @@ public interface OffsetFlushPolicy {
         return new AlwaysFlushOffsetPolicy();
     }
 
+    static OffsetFlushPolicy never() {
+        return new NeverFlushOffsetPolicy();
+    }
+
     static OffsetFlushPolicy periodic(Duration offsetFlushInterval, long maxOffsetFlushSize) {
         return new PeriodicFlushOffsetPolicy(offsetFlushInterval, maxOffsetFlushSize);
     }
@@ -47,6 +51,14 @@ public interface OffsetFlushPolicy {
         @Override
         public boolean shouldFlush(Duration timeSinceLastFlush, long numOfRecordsSinceLastFlush) {
             return true;
+        }
+    }
+
+    class NeverFlushOffsetPolicy implements OffsetFlushPolicy {
+
+        @Override
+        public boolean shouldFlush(Duration timeSinceLastFlush, long numOfRecordsSinceLastFlush) {
+            return false;
         }
     }
 }

--- a/core/src/main/java/io/debezium/connector/cassandra/OffsetWriter.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/OffsetWriter.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.cassandra;
 
+import java.util.concurrent.Future;
+
 /**
  * Interface for recording offset.
  */
@@ -16,7 +18,7 @@ public interface OffsetWriter {
      * @param sourceOffset string in the format of <file_name>:<file_position>
      * @param isSnapshot whether the offset is coming from a snapshot or commit log
      */
-    void markOffset(String sourceTable, String sourceOffset, boolean isSnapshot);
+    Future<?> markOffset(String sourceTable, String sourceOffset, boolean isSnapshot);
 
     /**
      * Determine if an offset has been processed based on the table name, offset position, and whether
@@ -31,7 +33,7 @@ public interface OffsetWriter {
     /**
      * Flush latest offsets to disk.
      */
-    void flush();
+    Future<?> flush();
 
     /**
      * Close all resources used by this class.

--- a/core/src/test/java/io/debezium/connector/cassandra/AbstractQueueProcessorTest.java
+++ b/core/src/test/java/io/debezium/connector/cassandra/AbstractQueueProcessorTest.java
@@ -50,8 +50,6 @@ public abstract class AbstractQueueProcessorTest {
                 context.getCassandraConnectorConfig(),
                 null,
                 context.getOffsetWriter(),
-                context.getCassandraConnectorConfig().offsetFlushIntervalMs(),
-                context.getCassandraConnectorConfig().maxOffsetFlushSize(),
                 context.getCassandraConnectorConfig().getKeyConverter(),
                 context.getCassandraConnectorConfig().getValueConverter(),
                 context.getErroneousCommitLogs(),

--- a/core/src/test/java/io/debezium/connector/cassandra/FileOffsetWriterTest.java
+++ b/core/src/test/java/io/debezium/connector/cassandra/FileOffsetWriterTest.java
@@ -107,6 +107,13 @@ public class FileOffsetWriterTest {
         process(commitLogRecordDiffTable);
 
         offsetWriter.flush();
+        // Sleep a little bit to ensure the operation is done
+        try {
+            Thread.sleep(100);
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         try (FileInputStream fis = new FileInputStream(offsetDir.toString() + "/" + FileOffsetWriter.SNAPSHOT_OFFSET_FILE)) {
             snapshotProps.load(fis);
         }
@@ -153,5 +160,12 @@ public class FileOffsetWriterTest {
                 record.getSource().keyspaceTable.name(),
                 record.getSource().offsetPosition.serialize(),
                 record.getSource().snapshot);
+        // Sleep a little bit to ensure the operation is done
+        try {
+            Thread.sleep(100);
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/core/src/test/java/io/debezium/connector/cassandra/TestingKafkaRecordEmitter.java
+++ b/core/src/test/java/io/debezium/connector/cassandra/TestingKafkaRecordEmitter.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.cassandra;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -19,11 +18,9 @@ public class TestingKafkaRecordEmitter extends KafkaRecordEmitter {
     public List<ProducerRecord<byte[], byte[]>> records = new ArrayList<>();
 
     public TestingKafkaRecordEmitter(CassandraConnectorConfig connectorConfig, KafkaProducer<byte[], byte[]> kafkaProducer,
-                                     OffsetWriter offsetWriter, Duration offsetFlushIntervalMs, long maxOffsetFlushSize,
-                                     Converter keyConverter, Converter valueConverter, Set<String> erroneousCommitLogs,
-                                     CommitLogTransfer commitLogTransfer) {
-        super(connectorConfig, kafkaProducer, offsetWriter, offsetFlushIntervalMs, maxOffsetFlushSize, keyConverter, valueConverter,
-                erroneousCommitLogs, commitLogTransfer);
+                                     OffsetWriter offsetWriter, Converter keyConverter, Converter valueConverter,
+                                     Set<String> erroneousCommitLogs, CommitLogTransfer commitLogTransfer) {
+        super(connectorConfig, kafkaProducer, offsetWriter, keyConverter, valueConverter, erroneousCommitLogs, commitLogTransfer);
     }
 
     @Override

--- a/dse/src/test/java/io/debezium/connector/dse/DseConnectorTestBase.java
+++ b/dse/src/test/java/io/debezium/connector/dse/DseConnectorTestBase.java
@@ -25,6 +25,6 @@ public abstract class DseConnectorTestBase extends CassandraConnectorTestBase {
         return new CassandraConnectorContext(config,
                 new DseSchemaLoader(),
                 new DseSchemaChangeListenerProvider(),
-                new FileOffsetWriter(config.offsetBackingStoreDir()));
+                new FileOffsetWriter(config));
     }
 }


### PR DESCRIPTION
delete synchronized block in KafkaRecordEmitter class to improve performance and use kafka producer callback. make FileOffsetWriter class operations async.