### PR TITLE
DBZ-8933 Improve field exclude list validation in FieldFilterSelector

### DIFF
--- a/core/src/main/java/io/debezium/connector/cassandra/FieldFilterSelector.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/FieldFilterSelector.java
@@ -8,6 +8,8 @@ package io.debezium.connector.cassandra;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.base.Strings;
+
 import io.debezium.connector.cassandra.CassandraSchemaFactory.RowData;
 
 /**
@@ -68,24 +70,21 @@ public class FieldFilterSelector {
             String[] elements = fieldExcludeList.split("\\.", -1);
             if (elements.length != 3) {
                 throw new IllegalArgumentException(
-                    "Invalid field exclude list format: '" + fieldExcludeList + 
-                    "'. Expected format: 'keyspace.table.column'"
-                );
+                        "Invalid field exclude list format: '" + fieldExcludeList +
+                                "'. Expected format: 'keyspace.table.column'");
             }
 
             String keyspace = elements[0].trim();
             String table = elements[1].trim();
             String column = elements[2].trim();
-            
+
             if (keyspace.isEmpty() || table.isEmpty() || column.isEmpty()) {
                 throw new IllegalArgumentException(
-                    "Keyspace, table, and column names cannot be empty in: '" + fieldExcludeList + "'"
-                );
+                        "Keyspace, table, and column names cannot be empty in: '" + fieldExcludeList + "'");
             }
 
             keyspaceTable = new KeyspaceTable(keyspace, table);
             this.column = column;
         }
     }
-
 }

--- a/core/src/main/java/io/debezium/connector/cassandra/FieldFilterSelector.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/FieldFilterSelector.java
@@ -61,11 +61,30 @@ public class FieldFilterSelector {
         final String column;
 
         private Field(String fieldExcludeList) {
-            String[] elements = fieldExcludeList.split("\\.", 3);
-            String keyspace = elements[0];
-            String table = elements[1];
+            if (Strings.isNullOrEmpty(fieldExcludeList)) {
+                throw new IllegalArgumentException("Field exclude list entry cannot be null or empty");
+            }
+
+            String[] elements = fieldExcludeList.split("\\.", -1);
+            if (elements.length != 3) {
+                throw new IllegalArgumentException(
+                    "Invalid field exclude list format: '" + fieldExcludeList + 
+                    "'. Expected format: 'keyspace.table.column'"
+                );
+            }
+
+            String keyspace = elements[0].trim();
+            String table = elements[1].trim();
+            String column = elements[2].trim();
+            
+            if (keyspace.isEmpty() || table.isEmpty() || column.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Keyspace, table, and column names cannot be empty in: '" + fieldExcludeList + "'"
+                );
+            }
+
             keyspaceTable = new KeyspaceTable(keyspace, table);
-            column = elements[2];
+            this.column = column;
         }
     }
 


### PR DESCRIPTION
- Add robust input validation for field exclude list entries
- Implement proper error handling with descriptive messages
- Validate format requirements (keyspace.table.column)
- Add whitespace trimming for all field components
- Prevent empty keyspace/table names
- Fix ArrayIndexOutOfBoundsException when parsing malformed entries

This change improves error reporting and prevents crashes when processing  incorrectly formatted field exclude list configurations in the Debezium  Cassandra connector.