### PR TITLE
debezium/dbz#1769 Add OpenTelemetry tracing to debezium-connector-cassandra

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,6 +19,11 @@
             <artifactId>commons-math3</artifactId>
             <version>3.2</version>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorConfig.java
@@ -357,6 +357,17 @@ public class CassandraConnectorConfig extends CommonConnectorConfig {
             .withValidation(Field::isRequired)
             .withDescription("The local directory which commit logs get relocated to once processed.");
 
+    public static final boolean DEFAULT_TRACING_ENABLED = false;
+    public static final Field TRACING_ENABLED = Field.create("tracing.enabled")
+            .withType(Type.BOOLEAN)
+            .withDefault(DEFAULT_TRACING_ENABLED)
+            .withDescription("Enables OpenTelemetry tracing. When enabled and the OpenTelemetry API "
+                    + "is on the classpath, the connector creates tracing spans for each change event.");
+
+    public boolean isTracingEnabled() {
+        return this.getConfig().getBoolean(TRACING_ENABLED);
+    }
+
     /**
      * If disabled, commit logs would not be deleted post-process, and this could lead to disk storage
      */

--- a/core/src/main/java/io/debezium/connector/cassandra/ComponentFactoryStandalone.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/ComponentFactoryStandalone.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
 import io.debezium.connector.cassandra.exceptions.CassandraConnectorConfigException;
+import io.debezium.connector.cassandra.tracing.TracingEmitter;
 
 public class ComponentFactoryStandalone implements ComponentFactory {
 
@@ -26,7 +27,7 @@ public class ComponentFactoryStandalone implements ComponentFactory {
     @Override
     public Emitter recordEmitter(CassandraConnectorContext context) {
         CassandraConnectorConfig config = context.getCassandraConnectorConfig();
-        return new KafkaRecordEmitter(
+        Emitter emitter = new KafkaRecordEmitter(
                 config,
                 new KafkaProducer<>(config.getKafkaConfigs()),
                 context.getOffsetWriter(),
@@ -34,6 +35,10 @@ public class ComponentFactoryStandalone implements ComponentFactory {
                 config.getValueConverter(),
                 context.getErroneousCommitLogs(),
                 config.getCommitLogTransfer());
+        if (config.isTracingEnabled()) {
+            return new TracingEmitter(emitter);
+        }
+        return emitter;
     }
 
 }

--- a/core/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/KafkaRecordEmitter.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.cassandra.tracing.TracingUtils;
 import io.debezium.spi.topic.TopicNamingStrategy;
 
 /**
@@ -67,7 +68,9 @@ public class KafkaRecordEmitter implements Emitter {
         String topic = topicNamingStrategy.dataChangeTopic(record.getSource().keyspaceTable);
         byte[] serializedKey = keyConverter.fromConnectData(topic, record.getKeySchema(), record.buildKey());
         byte[] serializedValue = valueConverter.fromConnectData(topic, record.getValueSchema(), record.buildValue());
-        return new ProducerRecord<>(topic, serializedKey, serializedValue);
+        ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(topic, serializedKey, serializedValue);
+        TracingUtils.injectProducerHeaders(producerRecord.headers());
+        return producerRecord;
     }
 
     private void callback(Record record, Exception exception) {

--- a/core/src/main/java/io/debezium/connector/cassandra/tracing/KafkaProducerHeadersSetter.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/tracing/KafkaProducerHeadersSetter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra.tracing;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.apache.kafka.common.header.Headers;
+
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+public enum KafkaProducerHeadersSetter implements TextMapSetter<Headers> {
+    INSTANCE;
+
+    KafkaProducerHeadersSetter() {
+    }
+
+    @Override
+    public void set(Headers headers, String key, String value) {
+        if (Objects.nonNull(headers)) {
+            headers.remove(key);
+            headers.add(key, value.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/core/src/main/java/io/debezium/connector/cassandra/tracing/TracingEmitter.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/tracing/TracingEmitter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra.tracing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.cassandra.Emitter;
+import io.debezium.connector.cassandra.Record;
+
+/**
+ * An {@link Emitter} decorator that wraps change event emission in OpenTelemetry tracing spans.
+ * Creates two nested spans per record:
+ * <ul>
+ *   <li>"db-log-write" — represents the original Cassandra write, backdated to the mutation timestamp</li>
+ *   <li>"debezium-read" — represents Debezium's processing, timestamped at emit time</li>
+ * </ul>
+ * The span gap between the two timestamps represents the CDC lag.
+ *
+ * <p>This decorator is only wired in when {@code tracing.enabled=true} is set in the connector config.
+ * If the OpenTelemetry API is not on the classpath, tracing is silently skipped and the delegate
+ * emitter is called directly.
+ */
+public class TracingEmitter implements Emitter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TracingEmitter.class);
+
+    private final Emitter delegate;
+
+    public TracingEmitter(Emitter delegate) {
+        this.delegate = delegate;
+        if (!TracingUtils.isOpenTelemetryAvailable()) {
+            LOGGER.warn("tracing.enabled=true but OpenTelemetry API is not on the classpath. Tracing will be skipped.");
+        }
+    }
+
+    @Override
+    public void emit(Record record) {
+        if (TracingUtils.isOpenTelemetryAvailable()) {
+            TracingUtils.traceEmit(record, () -> delegate.emit(record));
+        }
+        else {
+            delegate.emit(record);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        delegate.close();
+    }
+}

--- a/core/src/main/java/io/debezium/connector/cassandra/tracing/TracingUtils.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/tracing/TracingUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra.tracing;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.header.Headers;
+
+import io.debezium.connector.cassandra.Record;
+import io.debezium.connector.cassandra.SourceInfo;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+public final class TracingUtils {
+
+    private static final String TRACING_COMPONENT = "debezium";
+    private static final String DB_LOG_WRITE = "db-log-write";
+    private static final String DEBEZIUM_READ = "debezium-read";
+    private static final String DB_PREFIX = "db.";
+
+    private static final boolean OPEN_TELEMETRY_AVAILABLE = resolveOpenTelemetryApiAvailable();
+    // Only initialized when OTEL is available; null otherwise — avoids per-call GlobalOpenTelemetry.get()
+    private static final OpenTelemetry OPEN_TELEMETRY = OPEN_TELEMETRY_AVAILABLE ? GlobalOpenTelemetry.get() : null;
+    private static final Tracer TRACER = OPEN_TELEMETRY_AVAILABLE ? OPEN_TELEMETRY.getTracer(TRACING_COMPONENT) : null;
+
+    private TracingUtils() {
+    }
+
+    public static boolean isOpenTelemetryAvailable() {
+        return OPEN_TELEMETRY_AVAILABLE;
+    }
+
+    /**
+     * Creates two nested spans around the emit action:
+     * - "db-log-write" (backdated to the Cassandra mutation timestamp)
+     * - "debezium-read" as a child (timestamped at Debezium processing time)
+     * After the emit action, the current OTEL context is injected into the Kafka ProducerRecord
+     * headers via {@link KafkaProducerHeadersSetter} so downstream consumers can continue the trace.
+     */
+    public static void traceEmit(Record record, Runnable emitAction) {
+        SourceInfo source = record.getSource();
+        long tsMillis = source.tsMicro != null ? source.tsMicro.toEpochMilli() : 0L;
+
+        SpanBuilder dbLogSpanBuilder = TRACER.spanBuilder(DB_LOG_WRITE)
+                .setSpanKind(SpanKind.INTERNAL)
+                .setStartTimestamp(tsMillis, TimeUnit.MILLISECONDS);
+
+        Span dbLogSpan = dbLogSpanBuilder.startSpan();
+        try (Scope ignored = dbLogSpan.makeCurrent()) {
+            dbLogSpan.setAttribute(DB_PREFIX + "instance", source.keyspaceTable.keyspace);
+            dbLogSpan.setAttribute(DB_PREFIX + "type", source.connector);
+            dbLogSpan.setAttribute(DB_PREFIX + "cdc-name", source.cluster);
+            dbLogSpan.setAttribute(DB_PREFIX + "table", source.keyspaceTable.table);
+            dbLogSpan.setAttribute(DB_PREFIX + "snapshot", String.valueOf(source.snapshot));
+            dbLogSpan.setAttribute(DB_PREFIX + "file", source.offsetPosition.fileName);
+            dbLogSpan.setAttribute(DB_PREFIX + "pos", String.valueOf(source.offsetPosition.filePosition));
+            dbLogSpan.setAttribute(DB_PREFIX + "version", source.version);
+
+            Span debeziumSpan = TRACER.spanBuilder(DEBEZIUM_READ)
+                    .setStartTimestamp(record.getTs(), TimeUnit.MILLISECONDS)
+                    .startSpan();
+            try (Scope ignored2 = debeziumSpan.makeCurrent()) {
+                debeziumSpan.setAttribute("op", record.getOp().getValue());
+                debeziumSpan.setAttribute("ts_ms", String.valueOf(record.getTs()));
+
+                // KafkaRecordEmitter.toProducerRecord() calls TracingUtils.injectProducerHeaders()
+                // while this span is current, so the active context is propagated into record headers.
+                emitAction.run();
+            }
+            finally {
+                debeziumSpan.end();
+            }
+        }
+        finally {
+            dbLogSpan.end();
+        }
+    }
+
+    /**
+     * Injects the current OTEL context into Kafka producer record headers.
+     * Must be called from within a span scope (e.g. inside traceEmit).
+     * No-op if OTEL is not available.
+     */
+    public static void injectProducerHeaders(Headers headers) {
+        if (!OPEN_TELEMETRY_AVAILABLE) {
+            return;
+        }
+        OPEN_TELEMETRY.getPropagators().getTextMapPropagator()
+                .inject(Context.current(), headers, KafkaProducerHeadersSetter.INSTANCE);
+    }
+
+    private static boolean resolveOpenTelemetryApiAvailable() {
+        try {
+            GlobalOpenTelemetry.get();
+            return true;
+        }
+        catch (NoClassDefFoundError e) {
+            // ignored
+        }
+        return false;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -19,6 +19,11 @@
             <artifactId>debezium-connector-cassandra-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/tests/src/test/java/io/debezium/connector/cassandra/QueueProcessorTracingTest.java
+++ b/tests/src/test/java/io/debezium/connector/cassandra/QueueProcessorTracingTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra;
+
+import static com.datastax.oss.driver.api.core.type.DataTypes.INT;
+import static com.datastax.oss.driver.api.core.type.DataTypes.TEXT;
+import static io.debezium.connector.cassandra.CassandraSchemaFactory.CellData.ColumnType.CLUSTERING;
+import static io.debezium.connector.cassandra.CassandraSchemaFactory.CellData.ColumnType.PARTITION;
+import static io.debezium.connector.cassandra.CassandraSchemaFactory.CellData.ColumnType.REGULAR;
+import static io.debezium.connector.cassandra.CassandraSchemaFactory.RowData.rowSchema;
+import static io.debezium.connector.cassandra.KeyValueSchema.getPrimaryKeySchemas;
+import static io.debezium.connector.cassandra.Record.Operation.INSERT;
+import static io.debezium.connector.cassandra.utils.TestUtils.TEST_KEYSPACE_NAME;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.cassandra.CassandraSchemaFactory.RowData;
+import io.debezium.connector.cassandra.spi.ProvidersResolver;
+import io.debezium.connector.cassandra.tracing.TracingEmitter;
+import io.debezium.connector.cassandra.utils.TestUtils;
+import io.debezium.time.Conversions;
+
+/**
+ * Tests that QueueProcessor correctly processes and emits records when tracing is enabled
+ * via a TracingEmitter decorator. Verifies that all record types (CHANGE, TOMBSTONE, EOF)
+ * continue to work correctly with the decorator in place.
+ */
+public class QueueProcessorTracingTest {
+
+    private CassandraConnectorContext context;
+    private QueueProcessor queueProcessor;
+    private TestingKafkaRecordEmitter innerEmitter;
+    private KeyValueSchema keyValueSchema;
+    private SourceInfo sourceInfo;
+
+    @Before
+    public void setUp() throws Exception {
+        context = ProvidersResolver.resolveConnectorContextProvider()
+                .provideContextWithoutSchemaManagement(Configuration.from(TestUtils.generateDefaultConfigMap()));
+
+        innerEmitter = new TestingKafkaRecordEmitter(
+                context.getCassandraConnectorConfig(),
+                null,
+                context.getOffsetWriter(),
+                context.getCassandraConnectorConfig().getKeyConverter(),
+                context.getCassandraConnectorConfig().getValueConverter(),
+                context.getErroneousCommitLogs(),
+                context.getCassandraConnectorConfig().getCommitLogTransfer());
+
+        // Wrap with TracingEmitter as it would be when tracing.enabled=true
+        TracingEmitter tracingEmitter = new TracingEmitter(innerEmitter);
+        queueProcessor = new QueueProcessor(context, 0, tracingEmitter);
+
+        CassandraSchemaFactory schemaFactory = CassandraSchemaFactory.get();
+        RowData rowData = schemaFactory.rowData();
+        rowData.addCell(schemaFactory.cellData("p1", 1, null, PARTITION));
+        rowData.addCell(schemaFactory.cellData("c1", 2, null, CLUSTERING));
+        rowData.addCell(schemaFactory.cellData("col1", "col1value", null, REGULAR));
+        rowData.addCell(schemaFactory.cellData("col2", 3, null, REGULAR));
+
+        keyValueSchema = new KeyValueSchema.KeyValueSchemaBuilder()
+                .withKeyspace(TEST_KEYSPACE_NAME)
+                .withTable("cdc_table")
+                .withKafkaTopicPrefix(context.getCassandraConnectorConfig().getLogicalName())
+                .withSourceInfoStructMarker(context.getCassandraConnectorConfig().getSourceInfoStructMaker())
+                .withRowSchema(rowSchema(asList("col1", "col2"), asList(TEXT, INT)))
+                .withPrimaryKeyNames(asList("p1", "c1"))
+                .withPrimaryKeySchemas(getPrimaryKeySchemas(asList(INT, INT)))
+                .build();
+
+        sourceInfo = new SourceInfo(context.getCassandraConnectorConfig(), "cluster1",
+                new OffsetPosition("CommitLog-6-123.log", 0),
+                new KeyspaceTable(TEST_KEYSPACE_NAME, "cdc_table"), false,
+                Conversions.toInstantFromMicros(System.currentTimeMillis() * 1000));
+    }
+
+    @After
+    public void tearDown() {
+        context.cleanUp();
+    }
+
+    @Test
+    public void testChangeRecordEmittedThroughTracingDecorator() throws Exception {
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
+        Record record = new ChangeRecord(sourceInfo, CassandraSchemaFactory.get().rowData(),
+                keyValueSchema.keySchema(), keyValueSchema.valueSchema(), INSERT, false);
+
+        queue.enqueue(record);
+        queueProcessor.process();
+
+        assertEquals("Change record should be emitted through TracingEmitter", 1, innerEmitter.records.size());
+        assertEquals(queue.totalCapacity(), queue.remainingCapacity());
+    }
+
+    @Test
+    public void testTombstoneRecordEmittedThroughTracingDecorator() throws Exception {
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
+        Record record = new TombstoneRecord(sourceInfo, CassandraSchemaFactory.get().rowData(),
+                keyValueSchema.keySchema());
+
+        queue.enqueue(record);
+        queueProcessor.process();
+
+        assertEquals("Tombstone record should be emitted through TracingEmitter", 1, innerEmitter.records.size());
+        assertEquals(queue.totalCapacity(), queue.remainingCapacity());
+    }
+
+    @Test
+    public void testMultipleRecordsEmittedThroughTracingDecorator() throws Exception {
+        ChangeEventQueue<Event> queue = context.getQueues().get(0);
+        int numRecords = 3;
+        for (int i = 0; i < numRecords; i++) {
+            queue.enqueue(new ChangeRecord(sourceInfo, CassandraSchemaFactory.get().rowData(),
+                    keyValueSchema.keySchema(), keyValueSchema.valueSchema(), INSERT, false));
+        }
+
+        queueProcessor.process();
+
+        assertEquals("All records should be emitted through TracingEmitter", numRecords, innerEmitter.records.size());
+    }
+}

--- a/tests/src/test/java/io/debezium/connector/cassandra/TracingEmitterTest.java
+++ b/tests/src/test/java/io/debezium/connector/cassandra/TracingEmitterTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra;
+
+import static com.datastax.oss.driver.api.core.type.DataTypes.INT;
+import static com.datastax.oss.driver.api.core.type.DataTypes.TEXT;
+import static io.debezium.connector.cassandra.CassandraSchemaFactory.CellData.ColumnType.CLUSTERING;
+import static io.debezium.connector.cassandra.CassandraSchemaFactory.CellData.ColumnType.PARTITION;
+import static io.debezium.connector.cassandra.CassandraSchemaFactory.CellData.ColumnType.REGULAR;
+import static io.debezium.connector.cassandra.CassandraSchemaFactory.RowData.rowSchema;
+import static io.debezium.connector.cassandra.KeyValueSchema.getPrimaryKeySchemas;
+import static io.debezium.connector.cassandra.Record.Operation.INSERT;
+import static io.debezium.connector.cassandra.utils.TestUtils.TEST_KEYSPACE_NAME;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.cassandra.CassandraSchemaFactory.RowData;
+import io.debezium.connector.cassandra.spi.ProvidersResolver;
+import io.debezium.connector.cassandra.tracing.TracingEmitter;
+import io.debezium.connector.cassandra.tracing.TracingUtils;
+import io.debezium.connector.cassandra.utils.TestUtils;
+import io.debezium.time.Conversions;
+
+public class TracingEmitterTest {
+
+    private CassandraConnectorContext context;
+    private TestingKafkaRecordEmitter innerEmitter;
+    private TracingEmitter tracingEmitter;
+    private KeyValueSchema keyValueSchema;
+    private SourceInfo sourceInfo;
+
+    @Before
+    public void setUp() throws Exception {
+        context = ProvidersResolver.resolveConnectorContextProvider()
+                .provideContextWithoutSchemaManagement(Configuration.from(TestUtils.generateDefaultConfigMap()));
+
+        innerEmitter = new TestingKafkaRecordEmitter(
+                context.getCassandraConnectorConfig(),
+                null,
+                context.getOffsetWriter(),
+                context.getCassandraConnectorConfig().getKeyConverter(),
+                context.getCassandraConnectorConfig().getValueConverter(),
+                context.getErroneousCommitLogs(),
+                context.getCassandraConnectorConfig().getCommitLogTransfer());
+
+        tracingEmitter = new TracingEmitter(innerEmitter);
+
+        CassandraSchemaFactory schemaFactory = CassandraSchemaFactory.get();
+        RowData rowData = schemaFactory.rowData();
+        rowData.addCell(schemaFactory.cellData("p1", 1, null, PARTITION));
+        rowData.addCell(schemaFactory.cellData("c1", 2, null, CLUSTERING));
+        rowData.addCell(schemaFactory.cellData("col1", "value", null, REGULAR));
+        rowData.addCell(schemaFactory.cellData("col2", 3, null, REGULAR));
+
+        keyValueSchema = new KeyValueSchema.KeyValueSchemaBuilder()
+                .withKeyspace(TEST_KEYSPACE_NAME)
+                .withTable("cdc_table")
+                .withKafkaTopicPrefix(context.getCassandraConnectorConfig().getLogicalName())
+                .withSourceInfoStructMarker(context.getCassandraConnectorConfig().getSourceInfoStructMaker())
+                .withRowSchema(rowSchema(asList("col1", "col2"), asList(TEXT, INT)))
+                .withPrimaryKeyNames(asList("p1", "c1"))
+                .withPrimaryKeySchemas(getPrimaryKeySchemas(asList(INT, INT)))
+                .build();
+
+        sourceInfo = new SourceInfo(context.getCassandraConnectorConfig(), "test-cluster",
+                new OffsetPosition("CommitLog-6-123.log", 0),
+                new KeyspaceTable(TEST_KEYSPACE_NAME, "cdc_table"), false,
+                Conversions.toInstantFromMicros(System.currentTimeMillis() * 1000));
+    }
+
+    @After
+    public void tearDown() {
+        context.cleanUp();
+    }
+
+    @Test
+    public void testDelegatesEmitToInnerEmitter() {
+        Record record = new ChangeRecord(sourceInfo, CassandraSchemaFactory.get().rowData(),
+                keyValueSchema.keySchema(), keyValueSchema.valueSchema(), INSERT, false);
+
+        tracingEmitter.emit(record);
+
+        assertEquals("Record should be delegated to the inner emitter", 1, innerEmitter.records.size());
+    }
+
+    @Test
+    public void testMultipleRecordsDelegated() {
+        for (int i = 0; i < 5; i++) {
+            Record record = new ChangeRecord(sourceInfo, CassandraSchemaFactory.get().rowData(),
+                    keyValueSchema.keySchema(), keyValueSchema.valueSchema(), INSERT, false);
+            tracingEmitter.emit(record);
+        }
+
+        assertEquals("All records should be delegated to the inner emitter", 5, innerEmitter.records.size());
+    }
+
+    @Test
+    public void testTombstoneRecordDelegated() {
+        Record record = new TombstoneRecord(sourceInfo, CassandraSchemaFactory.get().rowData(),
+                keyValueSchema.keySchema());
+
+        tracingEmitter.emit(record);
+
+        assertEquals("Tombstone record should be delegated to the inner emitter", 1, innerEmitter.records.size());
+    }
+
+    @Test
+    public void testProducerRecordHasHeadersWhenTracingAvailable() {
+        // When OpenTelemetry is on the classpath (test scope), the no-op tracer is used.
+        // Verify that even with the no-op tracer, context injection is attempted (headers may be empty
+        // if no active span, but the call should not throw).
+        Record record = new ChangeRecord(sourceInfo, CassandraSchemaFactory.get().rowData(),
+                keyValueSchema.keySchema(), keyValueSchema.valueSchema(), INSERT, false);
+
+        tracingEmitter.emit(record);
+
+        assertEquals(1, innerEmitter.records.size());
+        // With the no-op OTEL SDK, headers will be empty (no-op propagator injects nothing),
+        // but the emit path must complete without errors.
+        assertFalse("ProducerRecord should be non-null", innerEmitter.records.isEmpty());
+    }
+
+    @Test
+    public void testOtelAvailabilityMatchesClasspathPresence() {
+        // opentelemetry-api is on the test classpath, so OTEL should be available
+        assertTrue("OpenTelemetry API should be available on the test classpath",
+                TracingUtils.isOpenTelemetryAvailable());
+    }
+}


### PR DESCRIPTION
## Summary
Since the Cassandra connector has zero tracing support, this PR instruments the CDC pipeline directly at the Kafka Emitter level, following the same OTEL span conventions as debezium-core.

Two nested OTEL spans are created per each Debezium event emitted:
- `db-log-write`: backdated to the Cassandra mutation timestamp (`tsMicro`), with source attributes: keyspace, table, cluster, commitlog file/position, snapshot flag, connector version
- `debezium-read`: timestamped at Debezium processing time, with `op` and `ts_ms`

A trace context is injected into Kafka `ProducerRecord` headers (`traceparent`) so downstream consumers can continue the distributed trace (e.g. Elasticsearch Sink).

Other Debezium connectors expose tracing via the `ActivateTracingSpan` SMT, but since the Cassandra connector is not based on the Kafka Connect framework that is not supported.

Tracing is enabled via `tracing.enabled=true` in connector config, disabled by default. If tracing is enabled but an OTEL jar is not provided, the connector will no-op instead of failing.

## Testing
New unit tests are included. Tested in Cassandra 5 cluster with Debezium `3.3.0-Final` version.

Fixes https://github.com/debezium/dbz/issues/1769