### PR TITLE
debezium/dbz#1791 Fix unbounded task queue in FileOffsetWriter causing heap exhaustion

### DIFF
--- a/core/src/main/java/io/debezium/connector/cassandra/FileOffsetWriter.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/FileOffsetWriter.java
@@ -17,9 +17,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +62,8 @@ public class FileOffsetWriter implements OffsetWriter {
 
     private final OffsetFlushPolicy offsetFlushPolicy;
     private final ExecutorService executorService;
+    private final AtomicBoolean flushPending = new AtomicBoolean(false);
+    private static final Future<?> COMPLETED_FUTURE = CompletableFuture.completedFuture(null);
 
     public FileOffsetWriter(CassandraConnectorConfig config) throws IOException {
         if (config.offsetBackingStoreDir() == null) {
@@ -90,10 +94,11 @@ public class FileOffsetWriter implements OffsetWriter {
 
     @Override
     public Future<?> markOffset(String sourceTable, String sourceOffset, boolean isSnapshot) {
-        return executorService.submit(() -> performMarkOffset(sourceTable, sourceOffset, isSnapshot));
-    }
-
-    private void performMarkOffset(String sourceTable, String sourceOffset, boolean isSnapshot) {
+        // Update the in-memory offset directly on the caller thread (Properties is a
+        // synchronized Hashtable, so this is thread-safe). Only the expensive disk
+        // flush is delegated to the single-threaded executor, and even then we skip
+        // the submission when a flush task is already pending so the unbounded queue
+        // can never grow beyond one entry.
         if (isSnapshot) {
             if (!isOffsetProcessed(sourceTable, sourceOffset, isSnapshot)) {
                 snapshotProps.setProperty(sourceTable, sourceOffset);
@@ -104,9 +109,13 @@ public class FileOffsetWriter implements OffsetWriter {
                 commitLogProps.setProperty(sourceTable, sourceOffset);
             }
         }
-        if (offsetFlushPolicy.shouldFlush()) {
-            this.performFlush();
+        if (offsetFlushPolicy.shouldFlush() && flushPending.compareAndSet(false, true)) {
+            return executorService.submit(() -> {
+                flushPending.set(false);
+                this.performFlush();
+            });
         }
+        return COMPLETED_FUTURE;
     }
 
     @Override


### PR DESCRIPTION
Closes debezium/dbz#1791

## Summary

- `FileOffsetWriter.markOffset()` submitted a lambda to a single-threaded executor with an unbounded `LinkedBlockingQueue` for every record produced to Kafka
- With the default `offset.flush.interval.ms=0` (`AlwaysFlushPolicy`), each task performed disk I/O — at ~6,000 records/sec the executor could only drain ~200 tasks/sec
- The queue accumulated millions of `FutureTask` objects over time, causing heap exhaustion, GC pressure, and Kafka producer latency degradation
- Restart temporarily fixed it until the queue filled again (~2 hours)

### Fix

Update the in-memory `Properties` directly on the caller thread (thread-safe since `Properties` extends `Hashtable`) and delegate only the disk flush to the executor. An `AtomicBoolean` guard ensures at most one flush task is ever queued.