### PR TITLE
debezium/dbz#1792 Handle NoSuchFileException race in CDC directory size calculation

### DIFF
--- a/core/src/main/java/io/debezium/connector/cassandra/CommitLogIdxProcessor.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CommitLogIdxProcessor.java
@@ -9,6 +9,8 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.time.Duration;
@@ -154,7 +156,20 @@ public class CommitLogIdxProcessor extends AbstractProcessor {
             }
             initial = false;
         }
-        metrics.setCdcDirectoryTotalBytes(FileUtils.sizeOfDirectory(cdcDir));
+        updateCdcDirectorySizeMetric();
         watcher.poll();
+    }
+
+    private void updateCdcDirectorySizeMetric() {
+        try {
+            metrics.setCdcDirectoryTotalBytes(FileUtils.sizeOfDirectory(cdcDir));
+        }
+        catch (UncheckedIOException e) {
+            if (e.getCause() instanceof NoSuchFileException) {
+                LOGGER.debug("Skipping CDC directory size update because files moved during scan of {}", cdcDir, e);
+                return;
+            }
+            throw e;
+        }
     }
 }

--- a/core/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CommitLogProcessor.java
@@ -9,6 +9,8 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.time.Duration;
@@ -113,8 +115,21 @@ public class CommitLogProcessor extends AbstractProcessor {
             }
             initial = false;
         }
-        metrics.setCdcDirectoryTotalBytes(FileUtils.sizeOfDirectory(cdcDir));
+        updateCdcDirectorySizeMetric();
         watcher.poll();
+    }
+
+    private void updateCdcDirectorySizeMetric() {
+        try {
+            metrics.setCdcDirectoryTotalBytes(FileUtils.sizeOfDirectory(cdcDir));
+        }
+        catch (UncheckedIOException e) {
+            if (e.getCause() instanceof NoSuchFileException) {
+                LOGGER.debug("Skipping CDC directory size update because files moved during scan of {}", cdcDir, e);
+                return;
+            }
+            throw e;
+        }
     }
 
     void processCommitLog(File file) {


### PR DESCRIPTION
Closes debezium/dbz#1792

## Summary

- `FileUtils.sizeOfDirectory()` iterates directory entries and reads file sizes via `PathUtils.sizeOfDirectory()` through `Uncheck.get()`
- If the commit log relocation thread moves a file between the directory listing and the size read, `NoSuchFileException` is thrown wrapped in `UncheckedIOException`
- This kills the processor thread, halting all CDC processing until restart

### Fix

Catch `UncheckedIOException` with `NoSuchFileException` cause, log at debug level, and skip the metric update. Other IO errors are re-thrown. Applied to both `CommitLogIdxProcessor` and `CommitLogProcessor`.