### PR TITLE
debezium/dbz#1996 Fix template NPE during startup

### DIFF
--- a/cassandra-3/src/main/java/io/debezium/connector/cassandra/Cassandra3ConnectorTask.java
+++ b/cassandra-3/src/main/java/io/debezium/connector/cassandra/Cassandra3ConnectorTask.java
@@ -8,8 +8,8 @@ package io.debezium.connector.cassandra;
 public class Cassandra3ConnectorTask extends AbstractConnectorTask {
 
     @Override
-    protected CassandraConnectorTaskTemplate init(CassandraConnectorConfig conf, ComponentFactory factory) {
-        return CassandraConnectorTask.init(conf, factory);
+    protected CassandraConnectorTaskTemplate init(CassandraConnectorConfig conf) {
+        return CassandraConnectorTask.init(conf);
     }
 
 }

--- a/cassandra-3/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
+++ b/cassandra-3/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
@@ -45,10 +45,10 @@ public class CassandraConnectorTask {
     }
 
     public static void main(String[] args) throws Exception {
-        CassandraConnectorTaskTemplate.main(args, config -> init(config, new ComponentFactoryStandalone()));
+        CassandraConnectorTaskTemplate.main(args, CassandraConnectorTask::init, new ComponentFactoryStandalone());
     }
 
-    static CassandraConnectorTaskTemplate init(CassandraConnectorConfig config, ComponentFactory factory) {
+    static CassandraConnectorTaskTemplate init(CassandraConnectorConfig config) {
         return new CassandraConnectorTaskTemplate(config,
                 new Cassandra3TypeProvider(),
                 new Cassandra3SchemaLoader(),
@@ -59,7 +59,6 @@ public class CassandraConnectorTask {
                             new Cassandra3CommitLogSegmentReader(context, metrics),
                             new File(DatabaseDescriptor.getCDCLogLocation()),
                             new File(DatabaseDescriptor.getCommitLogLocation())) };
-                },
-                factory);
+                });
     }
 }

--- a/cassandra-4/src/main/java/io/debezium/connector/cassandra/Cassandra4ConnectorTask.java
+++ b/cassandra-4/src/main/java/io/debezium/connector/cassandra/Cassandra4ConnectorTask.java
@@ -8,8 +8,8 @@ package io.debezium.connector.cassandra;
 public class Cassandra4ConnectorTask extends AbstractConnectorTask {
 
     @Override
-    protected CassandraConnectorTaskTemplate init(CassandraConnectorConfig config, ComponentFactory factory) {
-        return CassandraConnectorTask.init(config, factory);
+    protected CassandraConnectorTaskTemplate init(CassandraConnectorConfig config) {
+        return CassandraConnectorTask.init(config);
     }
 
 }

--- a/cassandra-4/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
+++ b/cassandra-4/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
@@ -42,10 +42,10 @@ public class CassandraConnectorTask {
     }
 
     public static void main(String[] args) throws Exception {
-        CassandraConnectorTaskTemplate.main(args, config -> init(config, new ComponentFactoryStandalone()));
+        CassandraConnectorTaskTemplate.main(args, CassandraConnectorTask::init, new ComponentFactoryStandalone());
     }
 
-    static CassandraConnectorTaskTemplate init(CassandraConnectorConfig config, ComponentFactory factory) {
+    static CassandraConnectorTaskTemplate init(CassandraConnectorConfig config) {
         return new CassandraConnectorTaskTemplate(config,
                 new Cassandra4TypeProvider(),
                 new Cassandra4SchemaLoader(),
@@ -55,7 +55,6 @@ public class CassandraConnectorTask {
                     return new AbstractProcessor[]{ new CommitLogIdxProcessor(context, metrics,
                             new Cassandra4CommitLogSegmentReader(context, metrics),
                             new File(DatabaseDescriptor.getCDCLogLocation())) };
-                },
-                factory);
+                });
     }
 }

--- a/cassandra-4/src/test/java/io/debezium/connector/cassandra/Cassandra4ConnectorTaskTest.java
+++ b/cassandra-4/src/test/java/io/debezium/connector/cassandra/Cassandra4ConnectorTaskTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cassandra;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.cassandra.utils.TestUtils;
+import io.debezium.connector.common.CdcSourceTaskContext;
+
+class Cassandra4ConnectorTaskTest {
+
+    @Test
+    void shouldCreateTaskContextDuringPreStart() throws Exception {
+        Cassandra4ConnectorTask task = new Cassandra4ConnectorTask();
+
+        CdcSourceTaskContext<?> taskContext = task.preStart(Configuration.from(TestUtils.generateDefaultConfigMap()));
+
+        assertNotNull(taskContext);
+    }
+}

--- a/cassandra-5/src/main/java/io/debezium/connector/cassandra/Cassandra5ConnectorTask.java
+++ b/cassandra-5/src/main/java/io/debezium/connector/cassandra/Cassandra5ConnectorTask.java
@@ -8,8 +8,8 @@ package io.debezium.connector.cassandra;
 public class Cassandra5ConnectorTask extends AbstractConnectorTask {
 
     @Override
-    protected CassandraConnectorTaskTemplate init(CassandraConnectorConfig config, ComponentFactory factory) {
-        return CassandraConnectorTask.init(config, factory);
+    protected CassandraConnectorTaskTemplate init(CassandraConnectorConfig config) {
+        return CassandraConnectorTask.init(config);
     }
 
 }

--- a/cassandra-5/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
+++ b/cassandra-5/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTask.java
@@ -42,10 +42,10 @@ public class CassandraConnectorTask {
     }
 
     public static void main(String[] args) throws Exception {
-        CassandraConnectorTaskTemplate.main(args, config -> init(config, new ComponentFactoryStandalone()));
+        CassandraConnectorTaskTemplate.main(args, CassandraConnectorTask::init, new ComponentFactoryStandalone());
     }
 
-    static CassandraConnectorTaskTemplate init(CassandraConnectorConfig config, ComponentFactory factory) {
+    static CassandraConnectorTaskTemplate init(CassandraConnectorConfig config) {
         return new CassandraConnectorTaskTemplate(config,
                 new Cassandra5TypeProvider(),
                 new Cassandra5SchemaLoader(),
@@ -55,7 +55,6 @@ public class CassandraConnectorTask {
                     return new AbstractProcessor[]{ new CommitLogIdxProcessor(context, metrics,
                             new Cassandra5CommitLogSegmentReader(context, metrics),
                             new File(DatabaseDescriptor.getCDCLogLocation())) };
-                },
-                factory);
+                });
     }
 }

--- a/core/src/main/java/io/debezium/connector/cassandra/AbstractConnectorTask.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/AbstractConnectorTask.java
@@ -48,6 +48,7 @@ public abstract class AbstractConnectorTask extends BaseSourceTask<CassandraPart
     public CdcSourceTaskContext<? extends CommonConnectorConfig> preStart(Configuration config) {
 
         connectorConfig = new CassandraConnectorConfig(config);
+        template = init(connectorConfig);
 
         return (DefaultCassandraConnectorContext) template.getTaskContext();
     }
@@ -78,10 +79,8 @@ public abstract class AbstractConnectorTask extends BaseSourceTask<CassandraPart
             previousOffset = offsetLoader.load(new HashMap<>());
         }
 
-        template = init(connectorConfig,
-                new ComponentFactoryDebezium(queue, previousOffsets.getTheOnlyPartition(), previousOffset));
         try {
-            template.start();
+            template.start(new ComponentFactoryDebezium(queue, previousOffsets.getTheOnlyPartition(), previousOffset));
         }
         catch (Exception e) {
             throw new CassandraConnectorTaskException(e);
@@ -89,7 +88,7 @@ public abstract class AbstractConnectorTask extends BaseSourceTask<CassandraPart
         return null;
     }
 
-    protected abstract CassandraConnectorTaskTemplate init(CassandraConnectorConfig conf, ComponentFactory factory);
+    protected abstract CassandraConnectorTaskTemplate init(CassandraConnectorConfig conf);
 
     @Override
     protected List<SourceRecord> doPoll() throws InterruptedException {

--- a/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorContext.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorContext.java
@@ -17,6 +17,8 @@ import io.debezium.util.LoggingContext;
  */
 public interface CassandraConnectorContext {
 
+    void init(SchemaLoader schemaLoader, SchemaChangeListenerProvider schemaChangeListenerProvider, OffsetWriter offsetWriter);
+
     void cleanUp();
 
     CassandraConnectorConfig getCassandraConnectorConfig();

--- a/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTaskTemplate.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTaskTemplate.java
@@ -53,10 +53,10 @@ public class CassandraConnectorTaskTemplate {
     private final SchemaLoader schemaLoader;
     private final SchemaChangeListenerProvider schemaChangeListenerProvider;
     private final CassandraSpecificProcessors cassandraSpecificProcessors;
-    private final ComponentFactory factory;
 
     public static void main(String[] args,
-                            Function<CassandraConnectorConfig, CassandraConnectorTaskTemplate> template)
+                            Function<CassandraConnectorConfig, CassandraConnectorTaskTemplate> templateFactory,
+                            ComponentFactory factory)
             throws Exception {
         if (args.length == 0) {
             throw new CassandraConnectorConfigException("CDC config file is required");
@@ -64,7 +64,7 @@ public class CassandraConnectorTaskTemplate {
 
         try (FileInputStream fis = new FileInputStream(args[0])) {
             CassandraConnectorConfig config = new CassandraConnectorConfig(Configuration.load(fis));
-            template.apply(config).run();
+            templateFactory.apply(config).run(factory);
         }
     }
 
@@ -72,14 +72,13 @@ public class CassandraConnectorTaskTemplate {
                                           CassandraTypeProvider deserializerProvider,
                                           SchemaLoader schemaLoader,
                                           SchemaChangeListenerProvider schemaChangeListener,
-                                          CassandraSpecificProcessors cassandraSpecificProcessors,
-                                          ComponentFactory factory) {
+                                          CassandraSpecificProcessors cassandraSpecificProcessors) {
         this.config = config;
         this.deserializerProvider = deserializerProvider;
         this.schemaLoader = schemaLoader;
         this.schemaChangeListenerProvider = schemaChangeListener;
         this.cassandraSpecificProcessors = cassandraSpecificProcessors;
-        this.factory = factory;
+        this.taskContext = new DefaultCassandraConnectorContext(config);
     }
 
     private void initJmxReporter(String domain) {
@@ -100,7 +99,7 @@ public class CassandraConnectorTaskTemplate {
         return buildInfo;
     }
 
-    public void start() throws Exception {
+    public void start(ComponentFactory factory) throws Exception {
         if (!config.validateAndRecord(config.getValidationFieldSet(), LOGGER::error)) {
             throw new CassandraConnectorConfigException("Failed to start connector with invalid configuration " +
                     "(see logs for actual errors)");
@@ -110,7 +109,7 @@ public class CassandraConnectorTaskTemplate {
         initDeserializer();
 
         LOGGER.info("Initializing Cassandra connector task context ...");
-        taskContext = new DefaultCassandraConnectorContext(config, schemaLoader, schemaChangeListenerProvider, factory.offsetWriter(config));
+        taskContext.init(schemaLoader, schemaChangeListenerProvider, factory.offsetWriter(config));
 
         LOGGER.info("Starting processor group ...");
         AbstractProcessor[] processors = cassandraSpecificProcessors.getProcessors(taskContext);
@@ -126,9 +125,9 @@ public class CassandraConnectorTaskTemplate {
         jmxReporter.start();
     }
 
-    private void run() throws Exception {
+    private void run(ComponentFactory factory) throws Exception {
         try {
-            start();
+            start(factory);
             while (processorGroup.isRunning()) {
                 Thread.sleep(1000);
             }

--- a/core/src/main/java/io/debezium/connector/cassandra/DefaultCassandraConnectorContext.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/DefaultCassandraConnectorContext.java
@@ -33,25 +33,25 @@ public class DefaultCassandraConnectorContext extends CdcSourceTaskContext<Cassa
                                             SchemaLoader schemaLoader,
                                             SchemaChangeListenerProvider schemaChangeListenerProvider,
                                             OffsetWriter offsetWriter) {
-        super(config.getConfig(), config, config.getCustomMetricTags());
+        this(config);
+        init(schemaLoader, schemaChangeListenerProvider, offsetWriter);
+    }
+
+    public void init(SchemaLoader schemaLoader,
+                     SchemaChangeListenerProvider schemaChangeListenerProvider,
+                     OffsetWriter offsetWriter) {
         this.offsetWriter = offsetWriter;
 
         try {
-            prepareQueues();
+            schemaLoader.load(getCassandraConnectorConfig().cassandraConfig());
 
-            // Loading up DDL schemas from disk
-            schemaLoader.load(config.cassandraConfig());
+            AbstractSchemaChangeListener schemaChangeListener = schemaChangeListenerProvider.provide(getCassandraConnectorConfig());
 
-            AbstractSchemaChangeListener schemaChangeListener = schemaChangeListenerProvider.provide(config);
+            this.cassandraClient = new CassandraClient(getCassandraConnectorConfig().cassandraDriverConfig(), schemaChangeListener);
 
-            // Setting up Cassandra driver
-            this.cassandraClient = new CassandraClient(config.cassandraDriverConfig(), schemaChangeListener);
-
-            // Setting up schema holder ...
             this.schemaHolder = schemaChangeListener.getSchemaHolder();
         }
         catch (Exception e) {
-            // Clean up CassandraClient and FileOffsetWrite if connector context fails to be completely initialized.
             cleanUp();
             throw new CassandraConnectorTaskException("Failed to initialize Cassandra Connector Context.", e);
         }

--- a/dse/src/main/java/io/debezium/connector/dse/Dse680ConnectorTask.java
+++ b/dse/src/main/java/io/debezium/connector/dse/Dse680ConnectorTask.java
@@ -14,14 +14,13 @@ import io.debezium.connector.cassandra.CassandraConnectorConfig;
 import io.debezium.connector.cassandra.CassandraConnectorContext;
 import io.debezium.connector.cassandra.CassandraConnectorTaskTemplate;
 import io.debezium.connector.cassandra.CommitLogProcessor;
-import io.debezium.connector.cassandra.ComponentFactory;
 import io.debezium.connector.cassandra.metrics.CassandraStreamingMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
 
 public class Dse680ConnectorTask extends AbstractConnectorTask {
 
     @Override
-    protected CassandraConnectorTaskTemplate init(CassandraConnectorConfig config, ComponentFactory factory) {
+    protected CassandraConnectorTaskTemplate init(CassandraConnectorConfig config) {
         return new CassandraConnectorTaskTemplate(config,
                 new DseTypeProvider(),
                 new DseSchemaLoader(),
@@ -29,8 +28,7 @@ public class Dse680ConnectorTask extends AbstractConnectorTask {
                 context -> {
                     CassandraStreamingMetrics metrics = new CassandraStreamingMetrics((CdcSourceTaskContext) context);
                     return new AbstractProcessor[]{ getCommitLogProcessor(context, metrics, new DseCommitLogReadHandlerImpl(context, metrics)) };
-                },
-                factory);
+                });
     }
 
     protected AbstractProcessor getCommitLogProcessor(CassandraConnectorContext context, CassandraStreamingMetrics metrics, CommitLogReadHandler handler) {


### PR DESCRIPTION
Fixes debezium/dbz#1996

## Description

Decouples the template instantiation from the factory, allowing for the task context to be accessible earlier to satisfy the requirements inside the new `preStart()` method, avoiding the NullPointerException.
