### PR TITLE
debezium/dbz#2276 Update to Jetty 12.1.11

### DIFF
--- a/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTaskTemplate.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTaskTemplate.java
@@ -16,18 +16,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.jmx.JmxReporter;
-import io.dropwizard.metrics.servlets.HealthCheckServlet;
-import io.dropwizard.metrics.servlets.MetricsServlet;
-import io.dropwizard.metrics.servlets.PingServlet;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.base.ChangeEventQueue;
@@ -37,6 +34,9 @@ import io.debezium.connector.cassandra.metrics.CassandraSnapshotMetrics;
 import io.debezium.connector.cassandra.network.BuildInfoServlet;
 import io.debezium.connector.cassandra.transforms.CassandraTypeDeserializer;
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.dropwizard.metrics.servlets.HealthCheckServlet;
+import io.dropwizard.metrics.servlets.MetricsServlet;
+import io.dropwizard.metrics.servlets.PingServlet;
 
 public class CassandraConnectorTaskTemplate {
 

--- a/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTaskTemplate.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/CassandraConnectorTaskTemplate.java
@@ -17,17 +17,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.jmx.JmxReporter;
-import com.codahale.metrics.servlets.HealthCheckServlet;
-import com.codahale.metrics.servlets.MetricsServlet;
-import com.codahale.metrics.servlets.PingServlet;
+import io.dropwizard.metrics.servlets.HealthCheckServlet;
+import io.dropwizard.metrics.servlets.MetricsServlet;
+import io.dropwizard.metrics.servlets.PingServlet;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.base.ChangeEventQueue;

--- a/core/src/main/java/io/debezium/connector/cassandra/network/BuildInfoServlet.java
+++ b/core/src/main/java/io/debezium/connector/cassandra/network/BuildInfoServlet.java
@@ -10,9 +10,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Map;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.debezium>${project.version}</version.debezium>
 
         <!-- Dependencies -->
-        <version.dropwizard>4.0.1</version.dropwizard>
+        <version.dropwizard>4.2.39</version.dropwizard>
         <version.embedded.cassandra>4.0.6</version.embedded.cassandra>
         <version.testcontainers>1.21.4</version.testcontainers>
         <version.junit5>5.10.1</version.junit5>
@@ -263,11 +263,11 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-servlets</artifactId>
+            <artifactId>metrics-jakarta-servlets</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Fixes debezium/dbz#2276

* Jetty moved to 12.1.11
* Jetty artifact renamed to jetty-ee10-servlet
* Dropwizard moved to 4.2.39
* Dropwizard metrics artifact renamed to metrics-jakarta-servlets

Requires https://github.com/debezium/debezium/pull/7714 to be merged first