### PR TITLE
debezium/dbz#2370 Update Cassandra 5

### DIFF
--- a/cassandra-5/src/test/resources/docker/Dockerfile
+++ b/cassandra-5/src/test/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/library/cassandra:5.0.2
+FROM mirror.gcr.io/library/cassandra:5.0.8
 
 ENV CASSANDRA_YAML=/opt/cassandra/conf
 


### PR DESCRIPTION
Fixes debezium/dbz#2370

Companion PR to https://github.com/debezium/debezium/pull/7769

Updates Dockerfile versions to match new dependencies.